### PR TITLE
chore: add GitHub Actions CI/CD and Discord deploy notifications

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -75,7 +75,7 @@ jobs:
       service: 'Frontend'
       image: ${{ needs.build-and-deploy.outputs.image }}
     secrets:
-      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
 
   notify-failure:
     needs: build-and-deploy
@@ -85,4 +85,4 @@ jobs:
       status: 'failure'
       service: 'Frontend'
     secrets:
-      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,6 +14,8 @@ env:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.set-image.outputs.image }}
 
     steps:
       - name: Checkout code
@@ -42,6 +44,10 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Set image name
+        id: set-image
+        run: echo "image=gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+
       - name: Build Docker image
         run: |
           docker build -t gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}:${{ github.sha }} -f fe/Dockerfile fe/
@@ -59,3 +65,24 @@ jobs:
                        docker stop ${{ env.IMAGE_NAME }} || true && \
                        docker rm ${{ env.IMAGE_NAME }} || true && \
                        docker run -d --name ${{ env.IMAGE_NAME }} -p 80:80 gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+
+  notify-success:
+    needs: build-and-deploy
+    if: success()
+    uses: ./.github/workflows/discord-deploy-notify.yml
+    with:
+      status: 'success'
+      service: 'Frontend'
+      image: ${{ needs.build-and-deploy.outputs.image }}
+    secrets:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+  notify-failure:
+    needs: build-and-deploy
+    if: failure()
+    uses: ./.github/workflows/discord-deploy-notify.yml
+    with:
+      status: 'failure'
+      service: 'Frontend'
+    secrets:
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,61 @@
+name: Deploy Frontend to Dev Server
+
+on:
+  push:
+    branches:
+      - develop
+
+env:
+  GCP_PROJECT_ID: v1-mvp
+  GCP_REGION: us-east1
+  GCP_ZONE: us-east1-b
+  IMAGE_NAME: fe-dev
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: fe/package-lock.json
+
+      - name: Install dependencies
+        working-directory: fe
+        run: npm ci
+
+      - name: Build
+        working-directory: fe
+        run: npm run build
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build Docker image
+        run: |
+          docker build -t gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}:${{ github.sha }} -f fe/Dockerfile fe/
+
+      - name: Push to Artifact Registry
+        run: |
+          gcloud auth configure-docker
+          docker push gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+
+      - name: Deploy to Dev Server
+        run: |
+          gcloud compute ssh ${{ secrets.DEV_INSTANCE_NAME }} \
+            --zone=${{ env.GCP_ZONE }} \
+            --command="docker pull gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}:${{ github.sha }} && \
+                       docker stop ${{ env.IMAGE_NAME }} || true && \
+                       docker rm ${{ env.IMAGE_NAME }} || true && \
+                       docker run -d --name ${{ env.IMAGE_NAME }} -p 80:80 gcr.io/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"

--- a/.github/workflows/discord-deploy-notify.yml
+++ b/.github/workflows/discord-deploy-notify.yml
@@ -1,0 +1,57 @@
+name: Discord Deploy Notification
+
+on:
+  workflow_call:
+    inputs:
+      status:
+        required: true
+        type: string
+      service:
+        required: true
+        type: string
+      image:
+        required: false
+        type: string
+    secrets:
+      DISCORD_WEBHOOK_URL:
+        required: true
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord Notification (Success)
+        if: inputs.status == 'success'
+        run: |
+          curl -sf -H "Content-Type: application/json" -d '{
+            "embeds": [{
+              "title": "✅ Deploy Success",
+              "description": "**${{ inputs.service }}** deployed to dev server",
+              "color": 3066993,
+              "fields": [
+                {"name": "Branch", "value": "'"${{ github.ref_name }}"'", "inline": true},
+                {"name": "Commit", "value": "'"${GITHUB_SHA::7}"'", "inline": true},
+                {"name": "Author", "value": "'"${{ github.actor }}"'", "inline": true},
+                {"name": "Image", "value": "`${{ inputs.image }}`", "inline": false}
+              ],
+              "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+            }]
+          }' "${{ secrets.DISCORD_WEBHOOK_URL }}"
+
+      - name: Discord Notification (Failure)
+        if: inputs.status == 'failure'
+        run: |
+          curl -sf -H "Content-Type: application/json" -d '{
+            "embeds": [{
+              "title": "❌ Deploy Failed",
+              "description": "**${{ inputs.service }}** deployment failed",
+              "color": 15158332,
+              "fields": [
+                {"name": "Branch", "value": "'"${{ github.ref_name }}"'", "inline": true},
+                {"name": "Commit", "value": "'"${GITHUB_SHA::7}"'", "inline": true},
+                {"name": "Author", "value": "'"${{ github.actor }}"'", "inline": true},
+                {"name": "Logs", "value": "[View Logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})", "inline": false}
+              ],
+              "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
+            }]
+          }' "${{ secrets.DISCORD_WEBHOOK_URL }}"

--- a/.github/workflows/discord-deploy-notify.yml
+++ b/.github/workflows/discord-deploy-notify.yml
@@ -13,7 +13,7 @@ on:
         required: false
         type: string
     secrets:
-      DISCORD_WEBHOOK_URL:
+      DISCORD_DEPLOY_WEBHOOK:
         required: true
 
 jobs:
@@ -36,7 +36,7 @@ jobs:
               ],
               "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
             }]
-          }' "${{ secrets.DISCORD_WEBHOOK_URL }}"
+          }' "${{ secrets.DISCORD_DEPLOY_WEBHOOK }}"
 
       - name: Discord Notification (Failure)
         if: inputs.status == 'failure'
@@ -54,4 +54,4 @@ jobs:
               ],
               "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
             }]
-          }' "${{ secrets.DISCORD_WEBHOOK_URL }}"
+          }' "${{ secrets.DISCORD_DEPLOY_WEBHOOK }}"

--- a/.github/workflows/discord-notify.yml
+++ b/.github/workflows/discord-notify.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Send Discord Notification
         env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_ISSUE_TRACKER }}
           EVENT_NAME: ${{ github.event_name }}
           ACTION: ${{ github.event.action }}
           REPO: ${{ github.repository }}

--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+COPY dist/ /usr/share/nginx/html/
+EXPOSE 80


### PR DESCRIPTION
## What
- Add dev server auto-deploy workflow (`deploy-dev.yml`) triggered on push to `develop`
- Add reusable Discord deploy notification workflow (`discord-deploy-notify.yml`)
- Separate Discord webhooks: `DISCORD_ISSUE_TRACKER` for issues/PRs, `DISCORD_DEPLOY_WEBHOOK` for deployments
- Add Dockerfile for NGINX-based frontend serving

## Why
- Automate frontend deployment to dev server on every push to `develop`
- Get Discord notifications for deploy success/failure in a dedicated channel
- Keep issue/PR notifications and deploy notifications in separate Discord channels

## Related Issue
#5