### PR TITLE
fix: correct import paths for HomePage and PlayersPage

### DIFF
--- a/fe/src/App.tsx
+++ b/fe/src/App.tsx
@@ -1,7 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import AppLayout from "./components/AppLayout";
-import Home from "./pages/Home";
-import Players from "./pages/Players";
+import Home from "./pages/HomePage";
+import Players from "./pages/PlayersPage";
 
 // 기존의 useState나 로고 import는 이제 필요 없으므로 지워줍니다.
 function App() {


### PR DESCRIPTION
## What
- Fix import paths in `App.tsx`: `./pages/Home` → `./pages/HomePage`, `./pages/Players` → `./pages/PlayersPage`

## Why
- Build was failing due to mismatched file names

## Related Issue