### PR TITLE
chore: switch FE deploy from Docker to scp

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -6,17 +6,11 @@ on:
       - develop
 
 env:
-  GCP_PROJECT_ID: v1-mvp
-  GCP_REGION: us-east1
   GCP_ZONE: us-east1-b
-  IMAGE_NAME: fe-dev
-  REGISTRY: us-east1-docker.pkg.dev
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    outputs:
-      image: ${{ steps.set-image.outputs.image }}
 
     steps:
       - name: Checkout code
@@ -45,28 +39,11 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Set image name
-        id: set-image
-        run: echo "image=${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}/${{ env.IMAGE_NAME }}:${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
-
-      - name: Build Docker image
-        run: |
-          docker build -t ${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}/${{ env.IMAGE_NAME }}:${{ github.sha }} -f fe/Dockerfile fe/
-
-      - name: Push to Artifact Registry
-        run: |
-          gcloud auth configure-docker ${{ env.REGISTRY }}
-          docker push ${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
-
       - name: Deploy to Dev Server
         run: |
-          gcloud compute ssh ${{ secrets.DEV_INSTANCE_NAME }} \
-            --zone=${{ env.GCP_ZONE }} \
-            --command="sudo gcloud auth configure-docker ${{ env.REGISTRY }} --quiet && \
-                       sudo docker pull ${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}/${{ env.IMAGE_NAME }}:${{ github.sha }} && \
-                       sudo docker stop ${{ env.IMAGE_NAME }} || true && \
-                       sudo docker rm ${{ env.IMAGE_NAME }} || true && \
-                       sudo docker run -d --name ${{ env.IMAGE_NAME }} -p 80:80 ${{ env.REGISTRY }}/${{ env.GCP_PROJECT_ID }}/${{ env.IMAGE_NAME }}/${{ env.IMAGE_NAME }}:${{ github.sha }}"
+          gcloud compute scp --recurse fe/dist/* \
+            ${{ secrets.DEV_INSTANCE_NAME }}:/app/fe/dist/ \
+            --zone=${{ env.GCP_ZONE }}
 
   notify-success:
     needs: build-and-deploy
@@ -75,7 +52,6 @@ jobs:
     with:
       status: 'success'
       service: 'Frontend'
-      image: ${{ needs.build-and-deploy.outputs.image }}
     secrets:
       DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}
 

--- a/.github/workflows/discord-deploy-notify.yml
+++ b/.github/workflows/discord-deploy-notify.yml
@@ -9,9 +9,6 @@ on:
       service:
         required: true
         type: string
-      image:
-        required: false
-        type: string
     secrets:
       DISCORD_DEPLOY_WEBHOOK:
         required: true
@@ -32,7 +29,6 @@ jobs:
                 {"name": "Branch", "value": "'"${{ github.ref_name }}"'", "inline": true},
                 {"name": "Commit", "value": "'"${GITHUB_SHA::7}"'", "inline": true},
                 {"name": "Author", "value": "'"${{ github.actor }}"'", "inline": true},
-                {"name": "Image", "value": "`${{ inputs.image }}`", "inline": false}
               ],
               "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'"
             }]

--- a/fe/Dockerfile
+++ b/fe/Dockerfile
@@ -1,3 +1,0 @@
-FROM nginx:alpine
-COPY dist/ /usr/share/nginx/html/
-EXPOSE 80

--- a/fe/src/types/home.ts
+++ b/fe/src/types/home.ts
@@ -1,0 +1,16 @@
+export type NewsItem = {
+  id: string;
+  title: string;
+  summary: string;
+  publishedAt: string; 
+  url?: string;
+  source?: string;
+};
+
+export type TopPlayer = {
+  id: string;
+  name: string;
+  team: string;
+  positions: string[];
+  valueScore: number;
+};


### PR DESCRIPTION
## What
- Replaced Docker image build + Artifact Registry push with `npm build` + `gcloud compute scp`
- Removed `fe/Dockerfile` (NGINX serving now handled by cl repo)
- Removed `image` input from Discord deploy notification workflow

## Why
- NGINX is now managed in the cl repo, so FE only needs to copy `dist/` to the server
- Simplifies the deploy pipeline by removing Docker/Artifact Registry dependency

## Related Issue