### PR TITLE
[Chore] Add prod deployment workflow (GCS bucket)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -1,0 +1,53 @@
+name: Deploy Frontend to Production
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  BUCKET: gs://v1-ppa-dun
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: fe/package-lock.json
+
+      - name: Install dependencies
+        working-directory: fe
+        run: npm ci
+
+      - name: Build
+        working-directory: fe
+        run: npm run build
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Upload to GCS
+        ## remove original files and use new ones z
+        run: gsutil -m rsync -r -d fe/dist ${{ env.BUCKET }}
+
+  notify:
+    needs: build-and-deploy
+    if: always()
+    uses: ./.github/workflows/discord-deploy-notify.yml
+    with:
+      status: ${{ needs.build-and-deploy.result }}
+      service: Frontend (Prod)
+    secrets:
+      DISCORD_DEPLOY_WEBHOOK: ${{ secrets.DISCORD_DEPLOY_WEBHOOK }}


### PR DESCRIPTION
## What
- Add `deploy-prod.yml` workflow (CI build → gsutil rsync to GCS bucket)
- Triggers on main branch push

## Why
Production frontend needs to be served via GCS + CDN. This workflow builds in CI and uploads the dist to the GCS bucket automatically.

## Related Issue
#15