### PR TITLE
Fix: remove redundant 'My |' prefix in Draft Room

### DIFF
--- a/fe/src/features/draft/components/DraftRoomBoard.tsx
+++ b/fe/src/features/draft/components/DraftRoomBoard.tsx
@@ -108,7 +108,7 @@ export default function DraftRoomBoard({
                       accent.header,
                     ].join(" ")}
                   >
-                    {team.isMine ? `My | ${team.name}` : team.name}
+                    {team.name}
                   </div>
 
                   <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Remove hardcoded `My | ` prefix from team name display in Draft Room board
- Previously showed "My | My Team" — now just shows the configured team name

## Related
Closes #26

## Test plan
- [ ] Open Draft Room and verify your team shows just the team name (e.g. "My Team"), not "My | My Team"