### PR TITLE
Fix: pass oppTeamNames to bootstrap API

### DIFF
--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -265,6 +265,7 @@ export default function DraftPage() {
         myTeamName: localConfig.myTeamName ?? "My Team",
         oppTeamName: localConfig.oppTeamName ?? "Team A",
         opponentsCount: localConfig.opponentsCount ?? 5,
+        oppTeamNames: localConfig.oppTeamNames ?? [],
         roomId: DRAFT_ROOM_ID,
       },
       controller.signal


### PR DESCRIPTION
## Summary
- Send `oppTeamNames` array in the bootstrap API call so the backend can use user-configured opponent names

## Related
Follow-up to #27 (merged) and #26

## Test plan
- [ ] Set custom opponent names in Draft Setup
- [ ] Open Draft Room and verify opponents show the configured names