### PR TITLE
Fix: pass oppTeamNames as comma-separated string

### DIFF
--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -265,7 +265,7 @@ export default function DraftPage() {
         myTeamName: localConfig.myTeamName ?? "My Team",
         oppTeamName: localConfig.oppTeamName ?? "Team A",
         opponentsCount: localConfig.opponentsCount ?? 5,
-        oppTeamNames: localConfig.oppTeamNames ?? [],
+        oppTeamNames: (localConfig.oppTeamNames ?? []).join(","),
         roomId: DRAFT_ROOM_ID,
       },
       controller.signal


### PR DESCRIPTION
## Summary
- Join `oppTeamNames` array with comma before sending to bootstrap API (fixes TS build error: `string[]` not assignable to `QueryValue`)

## Test plan
- [ ] Verify build passes
- [ ] Draft Room shows user-configured opponent names