### PR TITLE
Release: v0.2.2 - Fix draft room team naming

### DIFF
--- a/fe/src/features/draft/components/DraftRoomBoard.tsx
+++ b/fe/src/features/draft/components/DraftRoomBoard.tsx
@@ -108,7 +108,7 @@ export default function DraftRoomBoard({
                       accent.header,
                     ].join(" ")}
                   >
-                    {team.isMine ? `My | ${team.name}` : team.name}
+                    {team.name}
                   </div>
 
                   <div className="space-y-2">

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -265,6 +265,7 @@ export default function DraftPage() {
         myTeamName: localConfig.myTeamName ?? "My Team",
         oppTeamName: localConfig.oppTeamName ?? "Team A",
         opponentsCount: localConfig.opponentsCount ?? 5,
+        oppTeamNames: localConfig.oppTeamNames ?? [],
         roomId: DRAFT_ROOM_ID,
       },
       controller.signal

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -265,7 +265,7 @@ export default function DraftPage() {
         myTeamName: localConfig.myTeamName ?? "My Team",
         oppTeamName: localConfig.oppTeamName ?? "Team A",
         opponentsCount: localConfig.opponentsCount ?? 5,
-        oppTeamNames: localConfig.oppTeamNames ?? [],
+        oppTeamNames: (localConfig.oppTeamNames ?? []).join(","),
         roomId: DRAFT_ROOM_ID,
       },
       controller.signal


### PR DESCRIPTION
## Summary
- Remove redundant "My |" prefix from Draft Room team name display
- Pass `oppTeamNames` to bootstrap API so user-configured names are used

## Changes
- `DraftRoomBoard.tsx` — remove "My | " prefix, just show `team.name`
- `DraftPage.tsx` — send `oppTeamNames` as comma-separated string in bootstrap call

## Related
- FE issue: #26
- BE PR: Ppa-Dun-project/PPA-DUN-be#26