### PR TITLE
feat: replace mock news with real URLs and add /news page

### DIFF
--- a/fe/src/features/home/NewsCard.tsx
+++ b/fe/src/features/home/NewsCard.tsx
@@ -3,14 +3,15 @@ import { timeAgo } from "./utils";
 
 type Props = {
   item: NewsItem;
-  onClick: () => void;
 };
 
-export default function NewsCard({ item, onClick }: Props) {
+export default function NewsCard({ item }: Props) {
   return (
-    <button
-      onClick={onClick}
-      className="group w-full rounded-2xl border border-white/10 bg-white/5 p-5 text-left transition hover:bg-white/8 hover:-translate-y-[2px] active:translate-y-0"
+    <a
+      href={item.url}
+      target="_blank"
+      rel="noreferrer"
+      className="group block w-full rounded-2xl border border-white/10 bg-white/5 p-5 text-left transition hover:bg-white/8 hover:-translate-y-[2px] active:translate-y-0"
     >
       <div className="flex items-center justify-between gap-3">
         <div className="text-xs text-white/60">
@@ -27,6 +28,6 @@ export default function NewsCard({ item, onClick }: Props) {
       <p className="mt-2 line-clamp-2 text-sm text-white/70">
         {item.summary}
       </p>
-    </button>
+    </a>
   );
 }

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+﻿import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import FadeIn from "../components/ui/FadeIn";
 import Skeleton from "../components/ui/Skeleton";

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import FadeIn from "../components/ui/FadeIn";
-import Modal from "../components/ui/Modal";
 import Skeleton from "../components/ui/Skeleton";
 
 import type { NewsItem } from "../types/home";
@@ -29,7 +28,6 @@ export default function HomePage() {
   const [news, setNews] = useState<NewsItem[]>([]);
 
   const [query, setQuery] = useState("");
-  const [selected, setSelected] = useState<NewsItem | null>(null);
 
   const onSearch = () => {
     const q = query.trim();
@@ -132,9 +130,7 @@ export default function HomePage() {
 
               <button
                 className="text-xs font-bold text-white/60 hover:text-white transition"
-                onClick={() => {
-                  // TODO: If you add a dedicated news page later, navigate("/news")
-                }}
+                onClick={() => navigate("/news")}
               >
                 View all →
               </button>
@@ -164,7 +160,7 @@ export default function HomePage() {
               {!newsLoading &&
                 !newsError &&
                 news.map((item) => (
-                  <NewsCard key={item.id} item={item} onClick={() => setSelected(item)} />
+                  <NewsCard key={item.id} item={item} />
                 ))}
             </div>
           </section>
@@ -176,37 +172,6 @@ export default function HomePage() {
         </FadeIn>
       </div>
 
-      {/* News modal */}
-      <Modal
-        open={Boolean(selected)}
-        title={selected?.title}
-        onClose={() => setSelected(null)}
-        footer={
-          <>
-            {selected?.url && (
-              <a
-                href={selected.url}
-                target="_blank"
-                rel="noreferrer"
-                className="rounded-xl border border-white/15 px-4 py-2 text-sm font-bold text-white/90 hover:bg-white/5 transition"
-              >
-                Open link
-              </a>
-            )}
-            <button
-              onClick={() => setSelected(null)}
-              className="rounded-xl bg-white px-4 py-2 text-sm font-bold text-black hover:bg-white/90 transition"
-            >
-              Close
-            </button>
-          </>
-        }
-      >
-        <p className="text-sm leading-6">{selected?.summary}</p>
-        <div className="mt-4 text-xs text-white/50">
-          Published: {selected ? new Date(selected.publishedAt).toLocaleString() : ""}
-        </div>
-      </Modal>
     </div>
   );
 }

--- a/fe/src/pages/NewsPage.tsx
+++ b/fe/src/pages/NewsPage.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+
+import FadeIn from "../components/ui/FadeIn";
+import Skeleton from "../components/ui/Skeleton";
+import type { NewsItem } from "../types/home";
+import { apiGet } from "../lib/api";
+import { timeAgo } from "../features/home/utils";
+
+type NewsListResponse = {
+  items: NewsItem[];
+  total: number;
+};
+
+export default function NewsPage() {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [news, setNews] = useState<NewsItem[]>([]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setLoading(true);
+    setError(null);
+
+    apiGet<NewsListResponse>("/api/news", { limit: 20 }, controller.signal)
+      .then((data) => setNews(data.items))
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setNews([]);
+        setError(err instanceof Error ? err.message : "Unknown error");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setLoading(false);
+      });
+
+    return () => controller.abort();
+  }, []);
+
+  return (
+    <div className="space-y-6">
+      <FadeIn>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-extrabold text-white">All News</h1>
+            <p className="mt-1 text-sm text-white/60">
+              Latest MLB and fantasy baseball news
+            </p>
+          </div>
+          <Link
+            to="/"
+            className="rounded-xl border border-white/15 px-4 py-2 text-sm font-bold text-white/70 hover:text-white hover:bg-white/5 transition"
+          >
+            ← Back to Home
+          </Link>
+        </div>
+      </FadeIn>
+
+      <FadeIn delayMs={60}>
+        <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+          <div className="grid grid-cols-1 gap-4">
+            {loading && (
+              <>
+                <Skeleton className="h-28" />
+                <Skeleton className="h-28" />
+                <Skeleton className="h-28" />
+              </>
+            )}
+
+            {!loading && error && (
+              <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-200">
+                Failed to load news: {error}
+              </div>
+            )}
+
+            {!loading && !error && news.length === 0 && (
+              <div className="rounded-2xl border border-white/10 bg-black/20 p-4 text-sm text-white/70">
+                No news yet.
+              </div>
+            )}
+
+            {!loading &&
+              !error &&
+              news.map((item) => (
+                <a
+                  key={item.id}
+                  href={item.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="group block rounded-2xl border border-white/10 bg-white/5 p-5 transition hover:bg-white/8 hover:-translate-y-[2px] active:translate-y-0"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="text-xs text-white/60">
+                      {item.source ?? "News"} • {timeAgo(item.publishedAt)}
+                    </div>
+                    <div className="text-xs text-white/40 group-hover:text-white/60 transition">
+                      Open →
+                    </div>
+                  </div>
+                  <h3 className="mt-2 text-base font-semibold text-white">
+                    {item.title}
+                  </h3>
+                  <p className="mt-2 text-sm text-white/70">
+                    {item.summary}
+                  </p>
+                  <div className="mt-3 text-xs text-white/40">
+                    {new Date(item.publishedAt).toLocaleString()}
+                  </div>
+                </a>
+              ))}
+          </div>
+        </section>
+      </FadeIn>
+    </div>
+  );
+}

--- a/fe/src/router.tsx
+++ b/fe/src/router.tsx
@@ -5,6 +5,7 @@ import ProtectedRoute from "./components/ProtectedRoute";
 import HomePage from "./pages/HomePage";
 import DraftPage from "./pages/DraftPage";
 import PlayerDetailPage from "./pages/PlayerDetailPage";
+import NewsPage from "./pages/NewsPage";
 import LoginPage from "./pages/LoginPage";
 import MyTeamPage from "./pages/MyTeamPage";
 
@@ -14,6 +15,9 @@ export const router = createBrowserRouter([
     element: <AppLayout />,
     children: [
       { index: true, element: <HomePage /> },
+
+      // News
+      { path: "news", element: <NewsPage /> },
 
       // Draft
       { path: "draft", element: <DraftPage /> },


### PR DESCRIPTION
## What
<!-- What did you do? -->
Replaced mock news data with real MLB news URLs and made news cards link directly to external articles. Added a dedicated /news page for "View all" functionality.


## Why
<!-- Why did you do it? -->
The Latest News section on the landing page used placeholder data and opened a modal on click. Users need to access actual news sources directly, and a full news list page provides better browsability.


## Related Issue
<!-- e.g. #123 -->
#37 