### PR TITLE
feat: implement Google OAuth with MySQL user storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Environment files (contain secrets)
+backend/.env

--- a/fe/src/pages/LoginPage.tsx
+++ b/fe/src/pages/LoginPage.tsx
@@ -13,7 +13,7 @@ type GoogleCredentialResponse = {
 };
 
 type AuthResponse = {
-  token: string;
+  id: number;
   email: string;
   name: string;
 };
@@ -39,8 +39,9 @@ export default function LoginPage() {
       apiPost<AuthResponse, { credential: string }>("/api/auth/google/verify", {
         credential: response.credential,
       })
-        .then((data) => {
-          login(data.token);
+        .then(() => {
+          // Store the Google credential as the auth token
+          login(response.credential);
           navigate(redirect, { replace: true });
         })
         .catch((err) => {


### PR DESCRIPTION
## What
<!-- What did you do? -->
Added MySQL database integration to Google OAuth login. User data is now stored and retrieved from the ppadun.users table on each login.


## Why
<!-- Why did you do it? -->
Previously the auth flow only verified the Google token without persisting user data. This adds real user storage so the backend can identify and track users across sessions.


## Related Issue
<!-- e.g. #123 -->
#42 