### PR TITLE
Clean up myteampage

### DIFF
--- a/fe/src/features/myteam/utils.ts
+++ b/fe/src/features/myteam/utils.ts
@@ -1,5 +1,29 @@
 import type { MyTeamPlayer, MyTeamPosFilter, MyTeamSort } from "../../types/myteam";
 
+// MLB 팀 코드별 배지 색상 매핑 (팀 시그니처 컬러 반영)
+const TEAM_BADGE_CLASSES: Record<string, string> = {
+  NYY: "bg-sky-500/15 text-sky-200 border-sky-400/25",
+  LAD: "bg-blue-500/15 text-blue-200 border-blue-400/25",
+  NYM: "bg-indigo-500/15 text-indigo-200 border-indigo-400/25",
+  ATL: "bg-red-500/15 text-red-200 border-red-400/25",
+  PHI: "bg-rose-500/15 text-rose-200 border-rose-400/25",
+  HOU: "bg-orange-500/15 text-orange-200 border-orange-400/25",
+  LAA: "bg-amber-500/15 text-amber-200 border-amber-400/25",
+  CLE: "bg-violet-500/15 text-violet-200 border-violet-400/25",
+  KC: "bg-cyan-500/15 text-cyan-200 border-cyan-400/25",
+  SD: "bg-yellow-500/15 text-yellow-200 border-yellow-400/25",
+  TEX: "bg-emerald-500/15 text-emerald-200 border-emerald-400/25",
+  BAL: "bg-orange-500/15 text-orange-200 border-orange-400/25",
+  CIN: "bg-red-500/15 text-red-200 border-red-400/25",
+  SEA: "bg-teal-500/15 text-teal-200 border-teal-400/25",
+};
+
+/**
+ * 선수 목록 필터링
+ * - 이름/팀명 검색 (대소문자 무시)
+ * - 포지션 필터 (ALL이면 전체)
+ * - BENCH(1B) 같은 포맷도 포지션 문자열에 포함되면 매칭
+ */
 export function filterMyTeam(
   players: MyTeamPlayer[],
   query: string,
@@ -10,12 +34,14 @@ export function filterMyTeam(
   return players.filter((player) => {
     const matchesQuery =
       !q || player.name.toLowerCase().includes(q) || player.team.toLowerCase().includes(q);
-    const matchesPos = pos === "ALL" ? true : player.pos === pos;
+    const matchesPos = pos === "ALL" ? true : player.pos.includes(pos);
     return matchesQuery && matchesPos;
   });
 }
 
+/** 선수 목록 정렬 (정렬 옵션별 비교 함수 적용) */
 export function sortMyTeam(players: MyTeamPlayer[], sort: MyTeamSort): MyTeamPlayer[] {
+  // 원본 배열을 변경하지 않도록 복사본 사용
   const copy = [...players];
 
   switch (sort) {
@@ -40,39 +66,18 @@ export function sortMyTeam(players: MyTeamPlayer[], sort: MyTeamSort): MyTeamPla
   }
 }
 
+/** 타율을 .300 같은 야구식 표기로 포맷 (0이면 "-") */
 export function formatAvg(avg: number) {
   if (!avg) return "-";
   return avg.toFixed(3).replace("0.", ".");
 }
 
-export function computeRemainingBudget(totalBudget: number, players: MyTeamPlayer[]) {
-  const spent = players.reduce((sum, player) => sum + (player.cost ?? 0), 0);
-  return Math.max(0, totalBudget - spent);
-}
-
+/** MLB 팀 코드 → 배지 CSS 클래스. 매핑에 없으면 기본 회색 */
 export function teamBadgeClass(team: string): string {
-  const t = team.toUpperCase();
-
-  const map: Record<string, string> = {
-    NYY: "bg-sky-500/15 text-sky-200 border-sky-400/25",
-    LAD: "bg-blue-500/15 text-blue-200 border-blue-400/25",
-    NYM: "bg-indigo-500/15 text-indigo-200 border-indigo-400/25",
-    ATL: "bg-red-500/15 text-red-200 border-red-400/25",
-    PHI: "bg-rose-500/15 text-rose-200 border-rose-400/25",
-    HOU: "bg-orange-500/15 text-orange-200 border-orange-400/25",
-    LAA: "bg-amber-500/15 text-amber-200 border-amber-400/25",
-    CLE: "bg-violet-500/15 text-violet-200 border-violet-400/25",
-    KC: "bg-cyan-500/15 text-cyan-200 border-cyan-400/25",
-    SD: "bg-yellow-500/15 text-yellow-200 border-yellow-400/25",
-    TEX: "bg-emerald-500/15 text-emerald-200 border-emerald-400/25",
-    BAL: "bg-orange-500/15 text-orange-200 border-orange-400/25",
-    CIN: "bg-red-500/15 text-red-200 border-red-400/25",
-    SEA: "bg-teal-500/15 text-teal-200 border-teal-400/25",
-  };
-
-  return map[t] ?? "bg-white/10 text-white/80 border-white/15";
+  return TEAM_BADGE_CLASSES[team.toUpperCase()] ?? "bg-white/10 text-white/80 border-white/15";
 }
 
+/** PPA-DUN 점수에 따른 강조 스타일 (10점 이상이면 발광 효과) */
 export function valueScoreClass(value: number): string {
   if (value >= 10) {
     return "text-emerald-300 drop-shadow-[0_0_12px_rgba(16,185,129,0.55)]";

--- a/fe/src/lib/auth.ts
+++ b/fe/src/lib/auth.ts
@@ -2,18 +2,10 @@
 // - 외부 저장소(localStorage, window 이벤트 등)를 구독할 때 사용
 // - 저장소가 변경되면 자동으로 컴포넌트를 다시 렌더링
 import { useSyncExternalStore } from "react";
-import { API_BASE_URL } from "./api";
-import { DRAFT_ROOM_ID } from "./runtimeConfig";
 
 // localStorage에 저장할 토큰의 키 이름
 // - localStorage.getItem("ppadun_token")으로 접근
 export const TOKEN_KEY = "ppadun_token";
-
-// ── 로그아웃 시 백엔드의 드래프트 상태를 리셋할 URL ──
-// encodeURIComponent: 특수문자를 URL 안전하게 인코딩 (공백 → %20 등)
-const DRAFT_RESET_PATH = `/api/draft/reset?userId=${encodeURIComponent(DRAFT_ROOM_ID)}`;
-// API_BASE_URL이 있으면 절대경로, 없으면 상대경로 사용
-const DRAFT_RESET_URL = API_BASE_URL ? `${API_BASE_URL}${DRAFT_RESET_PATH}` : DRAFT_RESET_PATH;
 
 /**
  * 현재 로그인 상태인지 확인
@@ -95,16 +87,12 @@ export function login(token: string): void {
 
 /**
  * logout: 로그아웃
- * 1. 백엔드에 드래프트 리셋 요청 (응답 기다리지 않음)
- * 2. localStorage에서 토큰 삭제
- * 3. 모든 구독자에게 알림
+ * 1. localStorage에서 토큰 삭제
+ * 2. 모든 구독자에게 알림
+ *
+ * DB는 건드리지 않음 — 재로그인 시 드래프트 상태가 복원되어야 하므로.
  */
 export function logout(): void {
-  // void: Promise를 반환하지만 결과를 무시하겠다는 명시적 표시
-  // .catch(() => {}): 리셋 실패해도 무시 (토큰 삭제가 우선)
-  void fetch(DRAFT_RESET_URL, { method: "DELETE" }).catch(() => {});
-
-  // localStorage.removeItem: 저장된 데이터 삭제
   localStorage.removeItem(TOKEN_KEY);
   emit();
 }

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -45,8 +45,9 @@ import AddBidModal from "../features/draft/components/AddBidModal";
 import TakenBidModal from "../features/draft/components/TakenBidModal";
 import PlayerComparisonModal from "../features/draft/components/PlayerComparisonModal";
 import PlayerInfoModal from "../features/players/components/PlayerInfoModal";
+import Pagination from "../features/players/components/Pagination";
 
-const BACKEND_LIST_LIMIT = 200;
+const PAGE_SIZE = 30;
 
 const DEFAULT_POSITION_FILTERS: DraftPositionFilter[] = [
   "ALL",
@@ -186,6 +187,8 @@ export default function DraftPage() {
   const [query, setQuery] = useState(() => searchParams.get("query")?.trim() ?? "");
   const [position, setPosition] = useState<DraftPositionFilter>("ALL");
   const [sort, setSort] = useState<DraftSort>("score_desc");
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
 
   const [positionFilters, setPositionFilters] =
     useState<DraftPositionFilter[]>(DEFAULT_POSITION_FILTERS);
@@ -199,7 +202,6 @@ export default function DraftPage() {
   const [compareAId, setCompareAId] = useState<string | null>(null);
   const [compareBId, setCompareBId] = useState<string | null>(null);
   const [comparisonOpen, setComparisonOpen] = useState(false);
-  const [recommendationNoticeOpen, setRecommendationNoticeOpen] = useState(false); // V2 placeholder
   const [profilePlayerId, setProfilePlayerId] = useState<number | null>(null);     // Player info modal
 
   // Modal targets — which player the user clicked "Add" or "Taken" on.
@@ -314,7 +316,12 @@ export default function DraftPage() {
     return () => controller.abort();
   }, [localConfig]);
 
-  // Fetch player list whenever search query, position filter, or sort changes.
+  // Reset to first page when search/filter/sort changes.
+  useEffect(() => {
+    setPage(1);
+  }, [query, position, sort]);
+
+  // Fetch player list whenever search query, position filter, sort, or page changes.
   // Previous in-flight request is aborted via AbortController.
   useEffect(() => {
     const controller = new AbortController();
@@ -329,14 +336,15 @@ export default function DraftPage() {
         query: query.trim() || undefined,
         position,
         sort,
-        page: 1,
-        limit: BACKEND_LIST_LIMIT,
+        page,
+        limit: PAGE_SIZE,
       },
       controller.signal
     )
       .then((data) => {
         if (controller.signal.aborted) return;
         setPlayers(data.items);
+        setTotalPages(Math.max(1, data.totalPages));
       })
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return;
@@ -351,7 +359,7 @@ export default function DraftPage() {
       });
 
     return () => controller.abort();
-  }, [query, position, sort]);
+  }, [query, position, sort, page]);
 
   // Toggle player selection for A/B comparison (max 2 players).
   const handleCompareToggle = (playerId: string) => {
@@ -569,19 +577,6 @@ export default function DraftPage() {
         </section>
       </FadeIn>
 
-      <FadeIn delayMs={110}>
-        <div className="flex justify-end">
-          <button
-            type="button"
-            onClick={() => setRecommendationNoticeOpen(true)}
-            className="rounded-xl border border-fuchsia-400/35 bg-fuchsia-500/12 px-4 py-2 text-xs font-black text-fuchsia-100 transition hover:bg-fuchsia-500/20"
-            title="Recommendation popup will be connected later"
-          >
-            PPA-DUN Recommendation
-          </button>
-        </div>
-      </FadeIn>
-
       <FadeIn delayMs={120}>
         <section className="rounded-2xl border border-fuchsia-500/55 bg-[#1b1228] p-4 shadow-[0_0_22px_rgba(168,85,247,0.22)]">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
@@ -728,7 +723,7 @@ export default function DraftPage() {
                         : "hover:bg-white/5",
                     ].join(" ")}
                   >
-                    <div className="text-white/45">{idx + 1}</div>
+                    <div className="text-white/45">{(page - 1) * PAGE_SIZE + idx + 1}</div>
 
                     <div>
                       <button
@@ -835,6 +830,8 @@ export default function DraftPage() {
             Players and draft picks are loaded from backend APIs.
           </div>
         </section>
+
+        <Pagination page={page} totalPages={totalPages} onChange={setPage} />
       </FadeIn>
 
       {addTarget && (
@@ -873,31 +870,6 @@ export default function DraftPage() {
         onClose={closePlayerInfo}
       />
 
-      {recommendationNoticeOpen && (
-        <div className="fixed inset-0 z-[72] grid place-items-center p-4">
-          <button
-            type="button"
-            aria-label="Close recommendation notice"
-            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-            onClick={() => setRecommendationNoticeOpen(false)}
-          />
-          <div className="relative w-[92%] max-w-sm rounded-3xl border border-fuchsia-400/30 bg-[#130f1d] p-5 shadow-2xl">
-            <div className="text-lg font-black text-white">PPA-DUN Recommendation</div>
-            <div className="mt-2 text-sm font-semibold text-fuchsia-100">
-              Planned for development in V2.
-            </div>
-            <div className="mt-5 flex justify-end">
-              <button
-                type="button"
-                onClick={() => setRecommendationNoticeOpen(false)}
-                className="rounded-full border border-fuchsia-300/30 bg-fuchsia-600 px-5 py-1.5 text-sm font-bold text-white transition hover:bg-fuchsia-500"
-              >
-                OK
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/fe/src/pages/MyTeamPage.tsx
+++ b/fe/src/pages/MyTeamPage.tsx
@@ -1,60 +1,44 @@
-// My Team page (protected route — requires authentication).
-// Shows all players drafted to the user's team with search, position filter, and sort.
-// Displays budget tracking (total / spent / remaining).
-// Data fetched from GET /api/my-team/players; filter options from /api/my-team/filters/*.
-import { useEffect, useState } from "react";
+// 내 팀 페이지 (로그인 필수)
+// - 백엔드에서 드래프트한 선수 목록 + 예산 정보를 받아옴
+// - 필터/정렬/검색은 전부 프론트에서 처리 (백엔드는 원시 데이터만 제공)
+import { useEffect, useMemo, useState } from "react";
 import FadeIn from "../components/ui/FadeIn";
 import Skeleton from "../components/ui/Skeleton";
 import Dropdown from "../components/ui/Dropdown";
 
 import type { MyTeamPlayer, MyTeamPosFilter, MyTeamSort } from "../types/myteam";
-import { formatAvg, teamBadgeClass, valueScoreClass } from "../features/myteam/utils";
+import {
+  filterMyTeam,
+  formatAvg,
+  sortMyTeam,
+  teamBadgeClass,
+  valueScoreClass,
+} from "../features/myteam/utils";
 import { apiGet } from "../lib/api";
 import PlayerInfoModal from "../features/players/components/PlayerInfoModal";
-import { DRAFT_ROOM_ID, MY_TEAM_ID } from "../lib/runtimeConfig";
+import { DRAFT_ROOM_ID } from "../lib/runtimeConfig";
 
-type MyTeamPositionsResponse = {
-  positions: MyTeamPosFilter[];
-};
-
-type MyTeamSortOption = {
-  value: MyTeamSort;
-  label: string;
-};
-
-type MyTeamSortOptionsResponse = {
-  sorts: { value: string; label: string }[];
-};
-
+// 백엔드 GET /api/my-team/players 응답 타입
 type MyTeamPlayersResponse = {
   items: MyTeamPlayer[];
-  page: number;
-  limit: number;
-  total: number;
-  totalPages: number;
   totalBudget: number;
   spentBudget: number;
   remainingBudget: number;
 };
 
-const DEFAULT_POSITIONS: MyTeamPosFilter[] = [
-  "ALL",
-  "C",
-  "1B",
-  "2B",
-  "3B",
-  "SS",
-  "OF",
-  "UTIL",
-  "LF",
-  "RF",
-  "CF",
-  "DH",
-  "SP",
-  "RP",
+// 예산 정보를 하나의 객체로 묶음 (useState 3번 → 1번)
+type Budget = { total: number; spent: number; remaining: number };
+
+const INITIAL_BUDGET: Budget = { total: 260, spent: 0, remaining: 260 };
+
+// 포지션 필터 옵션 (고정)
+const POSITION_FILTERS: MyTeamPosFilter[] = [
+  "ALL", "C", "1B", "2B", "3B", "SS", "OF", "UTIL",
+  "LF", "RF", "CF", "DH", "SP", "RP",
 ];
 
-const DEFAULT_SORT_OPTIONS: MyTeamSortOption[] = [
+// 정렬 옵션 (고정)
+const SORT_OPTIONS: { value: MyTeamSort; label: string }[] = [
   { value: "score_desc", label: "By Score" },
   { value: "cost_desc", label: "By Value $" },
   { value: "avg_desc", label: "By AVG" },
@@ -63,148 +47,67 @@ const DEFAULT_SORT_OPTIONS: MyTeamSortOption[] = [
   { value: "sb_desc", label: "By SB" },
 ];
 
-function cleanSortLabel(label: string) {
-  return label.replace(/\s*\((asc|desc)\)\s*/gi, "").trim();
-}
-
-function normalizeSortOptions(raw: { value: string; label: string }[]): MyTeamSortOption[] {
-  const preferred: MyTeamSort[] = [
-    "score_desc",
-    "cost_desc",
-    "avg_desc",
-    "hr_desc",
-    "rbi_desc",
-    "sb_desc",
-  ];
-
-  const byValue = new Map(raw.map((option) => [option.value, option]));
-  const seenLabels = new Set<string>();
-  const normalized: MyTeamSortOption[] = [];
-
-  for (const value of preferred) {
-    const option = byValue.get(value);
-    if (!option) continue;
-
-    const label = cleanSortLabel(option.label);
-    const key = label.toLowerCase();
-    if (seenLabels.has(key)) continue;
-
-    seenLabels.add(key);
-    normalized.push({ value, label });
-  }
-
-  return normalized.length > 0 ? normalized : DEFAULT_SORT_OPTIONS;
-}
+// 테이블 컬럼 그리드 정의 (헤더와 각 행에서 공유)
+const TABLE_GRID_COLS =
+  "grid-cols-[1.8fr_.6fr_.6fr_.7fr_.7fr_.7fr_.7fr_.7fr_.9fr]";
 
 export default function MyTeamPage() {
-  const [loading, setLoading] = useState(false);
+  // 로딩/에러 상태 (초기값 loading=true: 마운트 직후 API 호출 중)
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [players, setPlayers] = useState<MyTeamPlayer[]>([]);
 
-  // Filter and sort controls
+  // 백엔드에서 받아온 선수 목록 + 예산 정보
+  const [players, setPlayers] = useState<MyTeamPlayer[]>([]);
+  const [budget, setBudget] = useState<Budget>(INITIAL_BUDGET);
+
+  // 검색어 / 포지션 필터 / 정렬 상태
   const [query, setQuery] = useState("");
   const [pos, setPos] = useState<MyTeamPosFilter>("ALL");
   const [sort, setSort] = useState<MyTeamSort>("score_desc");
 
-  // Dynamic filter/sort options fetched from backend
-  const [positions, setPositions] = useState<MyTeamPosFilter[]>(DEFAULT_POSITIONS);
-  const [sortOptions, setSortOptions] = useState<MyTeamSortOption[]>(DEFAULT_SORT_OPTIONS);
-
-  // Budget tracking — updated from API response
-  const [remainingBudget, setRemainingBudget] = useState(260);
-  const [spentBudget, setSpentBudget] = useState(0);
-  const [totalBudget, setTotalBudget] = useState(260);
+  // 선수 정보 모달 상태 (선택된 선수 ID)
   const [profilePlayerId, setProfilePlayerId] = useState<number | null>(null);
 
-  // Fetch filter options (positions, sort) on mount.
+  // 마운트 시 한 번만 백엔드에서 내 팀 데이터 로드
   useEffect(() => {
     const controller = new AbortController();
-
-    Promise.all([
-      apiGet<MyTeamPositionsResponse>("/api/my-team/filters/positions", undefined, controller.signal),
-      apiGet<MyTeamSortOptionsResponse>("/api/my-team/filters/sorts", undefined, controller.signal),
-    ])
-      .then(([positionData, sortData]) => {
-        if (controller.signal.aborted) return;
-
-        if (positionData.positions.length > 0) {
-          setPositions(positionData.positions);
-          setPos((prev) => (positionData.positions.includes(prev) ? prev : "ALL"));
-        }
-
-        const normalizedSorts = normalizeSortOptions(sortData.sorts);
-        setSortOptions(normalizedSorts);
-        setSort((prev) =>
-          normalizedSorts.some((option) => option.value === prev)
-            ? prev
-            : normalizedSorts[0]?.value ?? "score_desc"
-        );
-      })
-      .catch((err: unknown) => {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        console.error(err);
-      });
-
-    return () => controller.abort();
-  }, []);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    queueMicrotask(() => {
-      setLoading(true);
-      setError(null);
-    });
 
     apiGet<MyTeamPlayersResponse>(
       "/api/my-team/players",
-      {
-        query: query.trim() || undefined,
-        position: pos,
-        sort,
-        page: 1,
-        limit: 200,
-        userId: DRAFT_ROOM_ID,
-        myTeamId: MY_TEAM_ID,
-      },
+      { userId: DRAFT_ROOM_ID },  // 백엔드 가이드: roomId → userId로 통일
       controller.signal
     )
       .then((data) => {
         if (controller.signal.aborted) return;
         setPlayers(data.items);
-        setRemainingBudget(data.remainingBudget);
-        setSpentBudget(data.spentBudget);
-        setTotalBudget(data.totalBudget);
+        setBudget({
+          total: data.totalBudget,
+          spent: data.spentBudget,
+          remaining: data.remainingBudget,
+        });
       })
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.error(err);
         setPlayers([]);
-        setError(err instanceof Error ? err.message : "Failed to load my team players");
+        setError(err instanceof Error ? err.message : "Failed to load my team");
       })
       .finally(() => {
-        if (!controller.signal.aborted) {
-          setLoading(false);
-        }
+        if (!controller.signal.aborted) setLoading(false);
       });
 
     return () => controller.abort();
-  }, [query, pos, sort]);
+  }, []);
 
-  const openPlayerInfo = (rawPlayerId: string) => {
-    const parsed = Number(rawPlayerId);
-    if (!Number.isFinite(parsed)) {
-      setError("Invalid player id");
-      return;
-    }
-    setProfilePlayerId(parsed);
-  };
-
-  const closePlayerInfo = () => {
-    setProfilePlayerId(null);
-  };
+  // 클라이언트 측 필터링 + 정렬 (백엔드 재호출 없이 메모리에서 계산)
+  const visiblePlayers = useMemo(
+    () => sortMyTeam(filterMyTeam(players, query, pos), sort),
+    [players, query, pos, sort]
+  );
 
   return (
     <div className="space-y-6">
+      {/* 상단: 제목 + 예산 카드 */}
       <FadeIn>
         <div className="flex items-center justify-between gap-4">
           <div>
@@ -214,16 +117,18 @@ export default function MyTeamPage() {
 
           <div className="flex items-center gap-3 rounded-2xl border border-white/10 bg-white/5 px-6 py-4">
             <div className="text-sm font-extrabold text-white/70">Budget</div>
-            <div className="text-xl font-black text-emerald-400">${remainingBudget}</div>
+            <div className="text-xl font-black text-emerald-400">${budget.remaining}</div>
             <div className="text-xs font-semibold text-white/50">
-              (${spentBudget} / ${totalBudget} spent)
+              (${budget.spent} / ${budget.total} spent)
             </div>
           </div>
         </div>
       </FadeIn>
 
+      {/* 본문: 검색/정렬/포지션 필터 + 선수 목록 테이블 */}
       <FadeIn delayMs={60} className="relative z-40">
         <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+          {/* 검색창 + 정렬 드롭다운 */}
           <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
             <div className="w-full lg:max-w-md">
               <div className="text-xs font-extrabold text-white/70">Search</div>
@@ -239,34 +144,33 @@ export default function MyTeamPage() {
               <Dropdown<MyTeamSort>
                 label="Sort"
                 value={sort}
-                options={sortOptions}
+                options={SORT_OPTIONS}
                 onChange={setSort}
               />
             </div>
           </div>
 
+          {/* 포지션 필터 칩 */}
           <div className="mt-4 flex flex-wrap gap-2">
-            {positions.map((position) => {
-              const active = pos === position;
-              return (
-                <button
-                  key={position}
-                  onClick={() => setPos(position)}
-                  className={[
-                    "rounded-full px-3 py-1 text-xs font-extrabold transition",
-                    active
-                      ? "bg-white text-black"
-                      : "border border-white/10 bg-white/5 text-white/80 hover:bg-white/10",
-                  ].join(" ")}
-                >
-                  {position}
-                </button>
-              );
-            })}
+            {POSITION_FILTERS.map((position) => (
+              <button
+                key={position}
+                onClick={() => setPos(position)}
+                className={`rounded-full px-3 py-1 text-xs font-extrabold transition ${
+                  pos === position
+                    ? "bg-white text-black"
+                    : "border border-white/10 bg-white/5 text-white/80 hover:bg-white/10"
+                }`}
+              >
+                {position}
+              </button>
+            ))}
           </div>
 
+          {/* 선수 목록 테이블 */}
           <div className="mt-5 overflow-hidden rounded-2xl border border-white/10">
-            <div className="grid grid-cols-[1.8fr_.6fr_.6fr_.7fr_.7fr_.7fr_.7fr_.7fr_.9fr] bg-black/40 px-4 py-3 text-xs font-extrabold text-white/60">
+            {/* 테이블 헤더 */}
+            <div className={`grid ${TABLE_GRID_COLS} bg-black/40 px-4 py-3 text-xs font-extrabold text-white/60`}>
               <div>Player</div>
               <div>Pos</div>
               <div>$</div>
@@ -278,6 +182,7 @@ export default function MyTeamPage() {
               <div className="text-right">PPA-DUN Value</div>
             </div>
 
+            {/* 테이블 본문: 로딩/에러/빈 상태/정상 4가지 분기 */}
             <div className="bg-black/20">
               {loading && (
                 <div className="p-4">
@@ -289,65 +194,65 @@ export default function MyTeamPage() {
                 <div className="p-4 text-sm text-red-200">Failed to load my team: {error}</div>
               )}
 
-              {!loading && !error && players.length === 0 && (
+              {!loading && !error && visiblePlayers.length === 0 && (
                 <div className="p-4 text-sm text-white/70">No players found.</div>
               )}
 
-              {!loading &&
-                !error &&
-                players.map((player) => (
-                  <div
-                    key={player.id}
-                    className="grid w-full grid-cols-[1.8fr_.6fr_.6fr_.7fr_.7fr_.7fr_.7fr_.7fr_.9fr] items-center px-4 py-3 text-left text-sm text-white/85 transition hover:bg-white/5"
-                  >
-                    <div>
-                      <button
-                        type="button"
-                        onClick={() => openPlayerInfo(player.id)}
-                        className="rounded-md border border-transparent px-2 py-1 -mx-2 -my-1 font-semibold text-white transition hover:border-white/35 hover:bg-white/5 hover:text-amber-200 focus-visible:border-white/45 focus-visible:bg-white/10 focus-visible:outline-none"
-                      >
-                        {player.name}
-                      </button>
-                    </div>
-
-                    <div>
-                      <span className="rounded-lg bg-white/10 px-2 py-1 text-xs font-extrabold text-white/80">
-                        {player.pos}
-                      </span>
-                    </div>
-
-                    <div className="font-semibold text-white/80">{player.cost}</div>
-
-                    <div>
-                      <span
-                        className={[
-                          "inline-flex items-center rounded-lg border px-2 py-1 text-xs font-extrabold",
-                          teamBadgeClass(player.team),
-                        ].join(" ")}
-                      >
-                        {player.team}
-                      </span>
-                    </div>
-
-                    <div className="text-white/70">{formatAvg(player.avg)}</div>
-                    <div className="font-semibold text-amber-300">{player.hr ?? "-"}</div>
-                    <div className="text-white/70">{player.rbi ?? "-"}</div>
-                    <div className="font-semibold text-amber-300">{player.sb ?? "-"}</div>
-
-                    <div className={`text-right text-sm font-black ${valueScoreClass(player.ppaValue)}`}>
-                      {player.ppaValue.toFixed(1)}
-                    </div>
+              {!loading && !error && visiblePlayers.map((player) => (
+                <div
+                  key={player.id}
+                  className={`grid w-full ${TABLE_GRID_COLS} items-center px-4 py-3 text-left text-sm text-white/85 transition hover:bg-white/5`}
+                >
+                  {/* 선수 이름 (클릭 시 모달) */}
+                  <div>
+                    <button
+                      type="button"
+                      onClick={() => setProfilePlayerId(Number(player.id))}
+                      className="rounded-md border border-transparent px-2 py-1 -mx-2 -my-1 font-semibold text-white transition hover:border-white/35 hover:bg-white/5 hover:text-amber-200 focus-visible:border-white/45 focus-visible:bg-white/10 focus-visible:outline-none"
+                    >
+                      {player.name}
+                    </button>
                   </div>
-                ))}
+
+                  {/* 포지션 배지 */}
+                  <div>
+                    <span className="rounded-lg bg-white/10 px-2 py-1 text-xs font-extrabold text-white/80">
+                      {player.pos}
+                    </span>
+                  </div>
+
+                  {/* 드래프트 비용 */}
+                  <div className="font-semibold text-white/80">{player.cost}</div>
+
+                  {/* MLB 팀 배지 (팀별 색상) */}
+                  <div>
+                    <span className={`inline-flex items-center rounded-lg border px-2 py-1 text-xs font-extrabold ${teamBadgeClass(player.team)}`}>
+                      {player.team}
+                    </span>
+                  </div>
+
+                  {/* 스탯 */}
+                  <div className="text-white/70">{formatAvg(player.avg)}</div>
+                  <div className="font-semibold text-amber-300">{player.hr ?? "-"}</div>
+                  <div className="text-white/70">{player.rbi ?? "-"}</div>
+                  <div className="font-semibold text-amber-300">{player.sb ?? "-"}</div>
+
+                  {/* PPA-DUN 가치 점수 (10점 이상이면 발광 효과) */}
+                  <div className={`text-right text-sm font-black ${valueScoreClass(player.ppaValue)}`}>
+                    {player.ppaValue.toFixed(1)}
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
         </section>
       </FadeIn>
 
+      {/* 선수 정보 모달 */}
       <PlayerInfoModal
         open={profilePlayerId !== null}
         playerId={profilePlayerId}
-        onClose={closePlayerInfo}
+        onClose={() => setProfilePlayerId(null)}
       />
     </div>
   );


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Paginated the Draft page player list (30 per page) instead of loading a fixed 200 items
- Changed backend /api/draft/players default limit from 50 to 30 and added a le=200 cap
- Cleaned up MyTeam page and features/myteam/utils.ts (removed redundant logic)

## Why
<!-- Why did you do it? -->
- Rendering 200 players at once was heavy; paginating to 30 improves UX and performance
- The backend limit had no upper bound, exposing the API to abuse — added le=200 as a safeguard
- MyTeam page had duplicated / unused code that reduced readability, matching the branch's cleanup goa

## Related Issue
<!-- e.g. #123 -->
#48 