### PR TITLE
improve client-side position filter logic

### DIFF
--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -59,9 +59,31 @@ const DEFAULT_POSITION_FILTERS: DraftPositionFilter[] = [
   "SS",
   "OF",
   "UTIL",
-  "SP",
-  "RP",
+  "P",
 ];
+
+// Match a player against a position filter.
+// - ALL   : always true
+// - UTIL  : any non-pitcher position (1B/2B/3B/SS/OF/C/UTIL all qualify)
+// - P     : any pitcher position (SP or RP)
+// - other : exact match (case-insensitive, defensive against empty arrays)
+function matchesPositionFilter(
+  playerPositions: readonly string[] | undefined,
+  filter: DraftPositionFilter
+): boolean {
+  if (filter === "ALL") return true;
+  if (!playerPositions || playerPositions.length === 0) return false;
+
+  const normalized = playerPositions.map((p) => p.toUpperCase());
+
+  if (filter === "UTIL") {
+    return normalized.some((p) => p !== "SP" && p !== "RP");
+  }
+  if (filter === "P") {
+    return normalized.some((p) => p === "SP" || p === "RP");
+  }
+  return normalized.includes(filter);
+}
 
 const DEFAULT_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
   { value: "score_desc", label: "By Score" },
@@ -232,7 +254,7 @@ export default function DraftPage() {
     }
 
     if (position !== "ALL") {
-      result = result.filter((p) => p.positions.includes(position as DraftPosition));
+      result = result.filter((p) => matchesPositionFilter(p.positions, position));
     }
 
     const sorted = [...result].sort((a, b) => {

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -76,6 +76,7 @@ export type DraftSort =
  */
 export type DraftPositionFilter =
   | "ALL"      // 전체
+  | "P"        // 투수 전체 (SP + RP)
   | "SP"       // 선발 투수
   | "RP"       // 구원 투수
   | "C"        // 포수


### PR DESCRIPTION
…on-pitchers

## What
<!-- What did you do? -->

Replaced the SP and RP filter buttons with a single P button that matches all pitchers, and expanded UTIL to match any non-pitcher position. Extracted the filter rule into a dedicated helper so each case (ALL, UTIL, P, exact match) is easy to reason about, with case-insensitive comparison and safe handling of empty position arrays.

## Why
<!-- Why did you do it? -->
RP returned zero results because the backend currently maps every pitcher to SP, and UTIL was too narrow — only DH/TWP players matched instead of the expected "any non-pitcher" convention. Consolidating the buttons fixes both at once without requiring backend changes, and filtering stays fully client-side so no extra network requests fire on button clicks.


## Related Issue
<!-- e.g. #123 -->
Closes #61 