### PR TITLE
refactor(utils): deduplicate PPA display and MLB team palette helpers

### DIFF
--- a/fe/src/features/draft/components/PlayerComparisonModal.tsx
+++ b/fe/src/features/draft/components/PlayerComparisonModal.tsx
@@ -1,6 +1,7 @@
 ﻿import { useCallback, useEffect, useMemo, useState } from "react";
 import { apiPost } from "../../../lib/api";
 import type { DraftPlayer } from "../../../types/draft";
+import { formatPpa } from "../../../utils/playerValue";
 
 type Props = {
   open: boolean;
@@ -333,7 +334,7 @@ export default function PlayerComparisonModal({ open, playerA, playerB, onClose 
                 <div className="shrink-0 text-right">
                   <div className="text-[10px] font-black uppercase tracking-widest text-white/60">PPA-DUN</div>
                   <div className="text-3xl font-black tabular-nums text-emerald-300">
-                    {Number.isFinite(playerA.ppaValue) ? playerA.ppaValue.toFixed(1) : "—"}
+                    {formatPpa(playerA.ppaValue)}
                   </div>
                 </div>
               </div>
@@ -367,7 +368,7 @@ export default function PlayerComparisonModal({ open, playerA, playerB, onClose 
                 <div className="shrink-0 text-right">
                   <div className="text-[10px] font-black uppercase tracking-widest text-white/60">PPA-DUN</div>
                   <div className="text-3xl font-black tabular-nums text-emerald-300">
-                    {Number.isFinite(playerB.ppaValue) ? playerB.ppaValue.toFixed(1) : "—"}
+                    {formatPpa(playerB.ppaValue)}
                   </div>
                 </div>
               </div>

--- a/fe/src/features/draft/utils.ts
+++ b/fe/src/features/draft/utils.ts
@@ -98,13 +98,6 @@ export function formatAvg(avg: number | null) {
   return avg.toFixed(3).replace("0.", ".");
 }
 
-/** PPA value style — blurred for unauthenticated users. */
-export function valueClass(v: number, authed: boolean) {
-  if (!authed) return "blur-sm select-none text-emerald-400/60";
-  if (v >= 10) return "text-emerald-300 drop-shadow-[0_0_12px_rgba(16,185,129,0.55)]";
-  return "text-emerald-400";
-}
-
 /** Draft cost style — blurred for unauthenticated users. */
 export function draftCostClass(authed: boolean) {
   return authed ? "text-white/80" : "blur-sm select-none text-white/50";

--- a/fe/src/features/home/TopPlayerCard.tsx
+++ b/fe/src/features/home/TopPlayerCard.tsx
@@ -1,4 +1,5 @@
 import type { TopPlayer } from "../../types/home";
+import { formatPpa } from "../../utils/playerValue";
 
 type Props = {
   player: TopPlayer;
@@ -20,7 +21,7 @@ export default function TopPlayerCard({ player, onClick }: Props) {
         </div>
 
         <div className="rounded-xl bg-white/10 px-3 py-1 text-xs font-semibold text-white">
-          {player.valueScore.toFixed(1)}
+          {formatPpa(player.valueScore)}
         </div>
       </div>
     </button>

--- a/fe/src/features/myteam/utils.ts
+++ b/fe/src/features/myteam/utils.ts
@@ -1,23 +1,5 @@
 import type { MyTeamPlayer, MyTeamPosFilter, MyTeamSort } from "../../types/myteam";
 
-// MLB 팀 코드별 배지 색상 매핑 (팀 시그니처 컬러 반영)
-const TEAM_BADGE_CLASSES: Record<string, string> = {
-  NYY: "bg-sky-500/15 text-sky-200 border-sky-400/25",
-  LAD: "bg-blue-500/15 text-blue-200 border-blue-400/25",
-  NYM: "bg-indigo-500/15 text-indigo-200 border-indigo-400/25",
-  ATL: "bg-red-500/15 text-red-200 border-red-400/25",
-  PHI: "bg-rose-500/15 text-rose-200 border-rose-400/25",
-  HOU: "bg-orange-500/15 text-orange-200 border-orange-400/25",
-  LAA: "bg-amber-500/15 text-amber-200 border-amber-400/25",
-  CLE: "bg-violet-500/15 text-violet-200 border-violet-400/25",
-  KC: "bg-cyan-500/15 text-cyan-200 border-cyan-400/25",
-  SD: "bg-yellow-500/15 text-yellow-200 border-yellow-400/25",
-  TEX: "bg-emerald-500/15 text-emerald-200 border-emerald-400/25",
-  BAL: "bg-orange-500/15 text-orange-200 border-orange-400/25",
-  CIN: "bg-red-500/15 text-red-200 border-red-400/25",
-  SEA: "bg-teal-500/15 text-teal-200 border-teal-400/25",
-};
-
 /**
  * 선수 목록 필터링
  * - 이름/팀명 검색 (대소문자 무시)
@@ -72,15 +54,3 @@ export function formatAvg(avg: number) {
   return avg.toFixed(3).replace("0.", ".");
 }
 
-/** MLB 팀 코드 → 배지 CSS 클래스. 매핑에 없으면 기본 회색 */
-export function teamBadgeClass(team: string): string {
-  return TEAM_BADGE_CLASSES[team.toUpperCase()] ?? "bg-white/10 text-white/80 border-white/15";
-}
-
-/** PPA-DUN 점수에 따른 강조 스타일 (10점 이상이면 발광 효과) */
-export function valueScoreClass(value: number): string {
-  if (value >= 10) {
-    return "text-emerald-300 drop-shadow-[0_0_12px_rgba(16,185,129,0.55)]";
-  }
-  return "text-emerald-400";
-}

--- a/fe/src/features/players/components/PlayerCard.tsx
+++ b/fe/src/features/players/components/PlayerCard.tsx
@@ -1,4 +1,5 @@
 import type { Player } from "../../../types/player";
+import { formatPpa } from "../../../utils/playerValue";
 
 type Props = {
   player: Player;
@@ -20,7 +21,7 @@ export default function PlayerCard({ player, onClick }: Props) {
         </div>
 
         <div className="rounded-xl bg-white/10 px-3 py-1 text-xs font-black text-white">
-          {player.valueScore.toFixed(1)}
+          {formatPpa(player.valueScore)}
         </div>
       </div>
 

--- a/fe/src/features/players/components/PlayerInfoModal.tsx
+++ b/fe/src/features/players/components/PlayerInfoModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { apiGet } from "../../../lib/api";
+import { formatPpa } from "../../../utils/playerValue";
 
 type Props = {
   open: boolean;
@@ -200,7 +201,7 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
               <div className="rounded-2xl border border-white/20 bg-black/20 px-5 py-3 text-center">
                 <div className="text-[11px] font-black uppercase tracking-wide text-white/60">PPA-DUN Value</div>
                 <div className="mt-1 text-3xl font-black text-emerald-300">
-                  {valueScore === null ? "-" : valueScore.toFixed(1)}
+                  {formatPpa(valueScore)}
                 </div>
               </div>
             </div>

--- a/fe/src/lib/auth.ts
+++ b/fe/src/lib/auth.ts
@@ -5,7 +5,7 @@ import { useSyncExternalStore } from "react";
 
 // localStorage에 저장할 토큰의 키 이름
 // - localStorage.getItem("ppadun_token")으로 접근
-export const TOKEN_KEY = "ppadun_token";
+export const TOKEN_KEY = "ppadun_JWT_token";
 
 /**
  * 현재 로그인 상태인지 확인

--- a/fe/src/lib/googleAuth.ts
+++ b/fe/src/lib/googleAuth.ts
@@ -17,8 +17,15 @@ export type GoogleCredentialResponse = {
 };
 
 // 백엔드가 반환하는 응답 타입 (우리 DB의 유저 정보)
-type AuthResponse = { id: number; email: string; name: string };
-
+type AuthResponse = {
+  access_token: string;
+  token_type: string;
+  user: {
+    id: number;
+    email: string;
+    name: string;
+  };
+};
 // Google의 전역 객체 타입 (window.google.accounts.id)
 // - Google Identity Services 스크립트가 index.html에서 로드됨
 type GoogleAccountsId = {
@@ -67,10 +74,8 @@ export function useGoogleSignIn(onSuccess: () => void) {
       apiPost<AuthResponse, { credential: string }>("/api/auth/google/verify", {
         credential: response.credential,
       })
-        .then(() => {
-          // 검증 성공: Google credential을 localStorage에 저장
-          login(response.credential);
-          // 성공 콜백 실행 (보통 페이지 이동)
+        .then((data) => {
+          login(data.access_token);
           onSuccess();
         })
         .catch((err) => console.error("Google login failed:", err));

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -38,8 +38,8 @@ import {
   getPlayerDraftStatus,
   mlbTeamBadgeClass,
   readDraftConfig,
-  valueClass,
 } from "../features/draft/utils";
+import { formatPpa, ppaValueClass } from "../utils/playerValue";
 
 import DraftRoomBoard from "../features/draft/components/DraftRoomBoard";
 import AddBidModal from "../features/draft/components/AddBidModal";
@@ -829,8 +829,8 @@ export default function DraftPage() {
                     <div className="text-white/70">{player.rbi ?? "-"}</div>
                     <div className="font-semibold text-amber-300">{player.sb ?? "-"}</div>
 
-                    <div className={`font-black ${valueClass(player.ppaValue, authed)}`}>
-                      {player.ppaValue.toFixed(1)}
+                    <div className={`font-black ${ppaValueClass(player.ppaValue, { authed })}`}>
+                      {formatPpa(player.ppaValue)}
                     </div>
 
                     <div className="flex items-center gap-2">

--- a/fe/src/pages/MyTeamPage.tsx
+++ b/fe/src/pages/MyTeamPage.tsx
@@ -11,9 +11,9 @@ import {
   filterMyTeam,
   formatAvg,
   sortMyTeam,
-  teamBadgeClass,
-  valueScoreClass,
 } from "../features/myteam/utils";
+import { mlbTeamBadgeClass } from "../features/draft/utils";
+import { formatPpa, ppaValueClass } from "../utils/playerValue";
 import { apiGet } from "../lib/api";
 import PlayerInfoModal from "../features/players/components/PlayerInfoModal";
 import { DRAFT_ROOM_ID } from "../lib/runtimeConfig";
@@ -226,7 +226,7 @@ export default function MyTeamPage() {
 
                   {/* MLB 팀 배지 (팀별 색상) */}
                   <div>
-                    <span className={`inline-flex items-center rounded-lg border px-2 py-1 text-xs font-extrabold ${teamBadgeClass(player.team)}`}>
+                    <span className={`inline-flex items-center rounded-lg border px-2 py-1 text-xs font-extrabold ${mlbTeamBadgeClass(player.team)}`}>
                       {player.team}
                     </span>
                   </div>
@@ -238,8 +238,8 @@ export default function MyTeamPage() {
                   <div className="font-semibold text-amber-300">{player.sb ?? "-"}</div>
 
                   {/* PPA-DUN 가치 점수 (10점 이상이면 발광 효과) */}
-                  <div className={`text-right text-sm font-black ${valueScoreClass(player.ppaValue)}`}>
-                    {player.ppaValue.toFixed(1)}
+                  <div className={`text-right text-sm font-black ${ppaValueClass(player.ppaValue)}`}>
+                    {formatPpa(player.ppaValue)}
                   </div>
                 </div>
               ))}

--- a/fe/src/pages/PlayerDetailPage.tsx
+++ b/fe/src/pages/PlayerDetailPage.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { apiGet } from "../lib/api";
+import { formatPpa } from "../utils/playerValue";
 
 type PlayerDetailResponse = {
   id: number;
@@ -104,7 +105,7 @@ export default function PlayerDetailPage() {
           </div>
         </div>
         <div className="rounded-2xl bg-white/10 px-4 py-2 text-sm font-black text-white">
-          ValueScore {player.valueScore.toFixed(1)}
+          ValueScore {formatPpa(player.valueScore)}
         </div>
       </div>
 

--- a/fe/src/utils/playerValue.ts
+++ b/fe/src/utils/playerValue.ts
@@ -1,0 +1,22 @@
+// PPA-DUN 값 표시를 위한 공통 유틸
+// - 이전에는 각 페이지/모달마다 .toFixed(1)과 스타일 분기가 흩어져 있었음
+// - 포매터와 스타일러를 단일 소스로 통합해 표시 정책을 한 곳에서 관리
+
+/** PPA-DUN 값을 소수 1자리로 포맷. 없거나 유한수가 아니면 "—" 반환. */
+export function formatPpa(value: number | null | undefined): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  return value.toFixed(1);
+}
+
+/**
+ * PPA-DUN 값에 적용할 Tailwind 클래스.
+ * - 비로그인: 블러 + 흐린 색 (유료 정보 마스킹)
+ * - 10점 이상: 에메랄드 발광 효과 (하이라이트)
+ * - 그 외: 기본 에메랄드
+ */
+export function ppaValueClass(value: number, opts?: { authed?: boolean }): string {
+  const authed = opts?.authed ?? true;
+  if (!authed) return "blur-sm select-none text-emerald-400/60";
+  if (value >= 10) return "text-emerald-300 drop-shadow-[0_0_12px_rgba(16,185,129,0.55)]";
+  return "text-emerald-400";
+}


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Add fe/src/utils/playerValue.ts with formatPpa() and ppaValueClass()
- Remove duplicate valueClass, TEAM_BADGE_CLASSES, teamBadgeClass, valueScoreClass
- Migrate 7 call sites (DraftPage, MyTeamPage, PlayerDetailPage, PlayerComparisonModal, PlayerInfoModal, TopPlayerCard, PlayerCard)
- Unify PPA fallback to em-dash "—"
- Also includes pre-existing auth.ts / googleAuth.ts changes (unrelated)
 
## Why
<!-- Why did you do it? -->
PPA `.toFixed(1)` was inlined in 7 files, and styling/team-palette helpers were copy-pasted between draft and myteam utils. Consolidating into shared helpers makes future display policy changes a one-line edit and eliminates drift risk.


## Related Issue
<!-- e.g. #123 -->
#65 