### PR TITLE
Fix/homepage latest news section is empty espn rss returns 422

### DIFF
--- a/fe/src/features/home/NewsCard.tsx
+++ b/fe/src/features/home/NewsCard.tsx
@@ -17,17 +17,36 @@ export default function NewsCard({ item }: Props) {
       href={item.url}
       target="_blank"
       rel="noreferrer"
-      className="group relative block w-full rounded-2xl border border-white/10 bg-white/5 p-5 text-left transition hover:bg-white/8 hover:-translate-y-[2px] active:translate-y-0"
+      className="group relative block w-full overflow-hidden rounded-2xl border border-white/10 bg-white/5 text-left transition hover:bg-white/8 hover:-translate-y-[2px] active:translate-y-0"
     >
-      {/* "Open →" 표시 — 우측 상단 코너에 절대 배치해서 제목이 카드 맨 위에 붙도록 함 */}
-      <div className="absolute right-5 top-5 text-xs text-white/40 group-hover:text-white/60 transition">
-        Open →
-      </div>
+      {/* 좌측 썸네일 + 우측 텍스트 가로 레이아웃. 이미지가 없으면 텍스트만 폭 100% */}
+      <div className="flex items-stretch gap-4">
+        {/* 썸네일: imageUrl이 있을 때만 렌더. onError로 깨진 이미지는 카드에서 숨김 */}
+        {item.imageUrl && (
+          <div className="relative hidden w-40 shrink-0 overflow-hidden bg-white/5 sm:block">
+            <img
+              src={item.imageUrl}
+              alt=""
+              loading="lazy"
+              className="h-full w-full object-cover transition group-hover:scale-105"
+              onError={(e) => { (e.currentTarget.parentElement as HTMLElement).style.display = "none"; }}
+            />
+          </div>
+        )}
 
-      {/* 뉴스 제목 — 우측의 Open 라벨과 겹치지 않도록 pr-12 여백 확보 */}
-      <h3 className="pr-12 text-base font-semibold text-white">{item.title}</h3>
-      {/* 뉴스 요약 (line-clamp-2: 최대 2줄까지만 표시, 넘치면 ...) */}
-      <p className="mt-2 line-clamp-2 text-sm text-white/70">{item.summary}</p>
+        {/* 텍스트 영역 */}
+        <div className="relative flex-1 p-5">
+          {/* "Open →" 표시 — 우측 상단 코너에 절대 배치해서 제목이 카드 맨 위에 붙도록 함 */}
+          <div className="absolute right-5 top-5 text-xs text-white/40 group-hover:text-white/60 transition">
+            Open →
+          </div>
+
+          {/* 뉴스 제목 — 우측의 Open 라벨과 겹치지 않도록 pr-12 여백 확보 */}
+          <h3 className="pr-12 text-base font-semibold text-white">{item.title}</h3>
+          {/* 뉴스 요약 (line-clamp-2: 최대 2줄까지만 표시, 넘치면 ...) */}
+          <p className="mt-2 line-clamp-2 text-sm text-white/70">{item.summary}</p>
+        </div>
+      </div>
     </a>
   );
 }

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -20,7 +20,15 @@ type Rss2JsonItem = {
   pubDate: string;
   description?: string;
   thumbnail?: string;
+  content?: string;        // HTML body — 첫 <img> 태그에서 썸네일 URL 추출에 사용
 };
+
+// rss2json content HTML에서 첫 번째 <img> 태그의 src 속성을 뽑는다.
+// Yahoo Sports feed는 thumbnail 필드는 비어있지만 content 안에 이미지를 포함.
+// 70% 정도의 항목에 이미지가 있고, 없는 항목은 undefined → 카드가 텍스트만 렌더.
+const IMG_SRC_RE = /<img[^>]+src="([^"]+)"/i;
+const extractImageUrl = (html: string | undefined): string | undefined =>
+  html ? html.match(IMG_SRC_RE)?.[1] : undefined;
 
 // 히어로 배너 배경 이미지
 import baseballImg from "../assets/Baseball.jpg";
@@ -54,6 +62,7 @@ export default function HomePage() {
             publishedAt: it.pubDate,
             url: it.link,
             source: "Yahoo Sports",
+            imageUrl: extractImageUrl(it.content),
           }));
           setNews(items);
         })

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ import DraftSetupCard from "../features/home/DraftSetupCard"; // 드래프트 �
 import SignInCard from "../features/home/SignInCard";        // 로그인 유도 카드 (비로그인 시)
 import type { NewsItem } from "../types/home";
 
-const MLB_RSS_URL = "https://www.mlb.com/feeds/news/rss.xml";
+const MLB_RSS_URL = "https://sports.yahoo.com/mlb/rss/";
 const RSS_TO_JSON_API = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(MLB_RSS_URL)}`;
 
 type Rss2JsonItem = {
@@ -53,7 +53,7 @@ export default function HomePage() {
             summary: (it.description ?? "").replace(/<[^>]+>/g, "").trim(),
             publishedAt: it.pubDate,
             url: it.link,
-            source: "MLB.com",
+            source: "Yahoo Sports",
           }));
           setNews(items);
         })
@@ -147,12 +147,12 @@ export default function HomePage() {
               <div>
                 <h2 className="text-lg font-bold text-white">Latest News</h2>
                 <p className="mt-1 text-xs text-white/50">
-                  Fetched from MLB.com · refreshes every hour
+                  Fetched from Yahoo Sports · refreshes every hour
                 </p>
               </div>
-              {/* "모두 보기" 버튼 → MLB.com 뉴스 페이지로 외부 이동 */}
+              {/* "모두 보기" 버튼 → Yahoo Sports MLB 뉴스 페이지로 외부 이동 */}
               <a
-                href="https://www.mlb.com/news"
+                href="https://sports.yahoo.com/mlb/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-xs font-bold text-white/60 hover:text-white transition"

--- a/fe/src/types/home.ts
+++ b/fe/src/types/home.ts
@@ -9,6 +9,7 @@ export type NewsItem = {
   publishedAt: string;     // 발행 시간 (ISO 문자열)
   url?: string;            // 원문 링크 (선택)
   source?: string;         // 출처 (선택, 예: "MLB.com")
+  imageUrl?: string;       // 썸네일 이미지 URL (선택, 없으면 텍스트만 표시)
 };
 
 /**


### PR DESCRIPTION
## What
- Switch HomePage Latest News RSS source to **Yahoo Sports MLB** (`sports.yahoo.com/mlb/rss/`)
- Show a **thumbnail image** on each `NewsCard` when one is available in the feed item

## Why
- The previous source (MLB.com) returns items with empty `description` and no `content`, so cards rendered with title only — visually bare
- Yahoo Sports provides rich descriptions for all items and image URLs embedded in `content` HTML for ~70% of items
- Cards now show real summary text + a thumbnail when present, gracefully falling back to text-only otherwise

## Related Issue
#72