### PR TITLE
feat: HomePage Injured Players strip + View All popup

### DIFF
--- a/fe/src/features/home/InjuredPlayerCard.tsx
+++ b/fe/src/features/home/InjuredPlayerCard.tsx
@@ -1,0 +1,66 @@
+import type { InjuredPlayer } from "../../types/home";
+
+/**
+ * InjuredPlayerCard: 단일 부상 선수 카드
+ * - HomePage strip(3장)과 View All popup 양쪽에서 재사용
+ * - status별로 색깔 구분 (Day-To-Day → yellow, IL → orange, Out/60-Day → red)
+ */
+
+// status → tailwind 클래스 매핑. 매칭 안 되는 status는 fallback 사용.
+const STATUS_TONE: Record<string, string> = {
+  "Day-To-Day": "text-yellow-300 bg-yellow-500/10 border-yellow-500/20",
+  "7-Day IL":   "text-orange-300 bg-orange-500/10 border-orange-500/20",
+  "10-Day IL":  "text-orange-300 bg-orange-500/10 border-orange-500/20",
+  "15-Day IL":  "text-orange-300 bg-orange-500/10 border-orange-500/20",
+  "60-Day IL":  "text-red-300 bg-red-500/10 border-red-500/20",
+  "Out":        "text-red-300 bg-red-500/10 border-red-500/20",
+};
+const FALLBACK_TONE = "text-white/60 bg-white/5 border-white/10";
+
+// MLB CDN 헤드샷 — player_id로 자동 조립.
+// 동일한 패턴이 PlayerInfoModal에서도 사용됨 (서비스 전반 일관성).
+const headshotUrl = (id: number) =>
+  `https://img.mlbstatic.com/mlb-photos/image/upload/w_120,q_auto:best/v1/people/${id}/headshot/67/current`;
+
+type Props = { item: InjuredPlayer };
+
+export default function InjuredPlayerCard({ item }: Props) {
+  const tone = STATUS_TONE[item.injury_status] ?? FALLBACK_TONE;
+
+  return (
+    <div className="group relative overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-4 transition hover:bg-white/8 hover:-translate-y-[2px]">
+      <div className="flex items-center gap-3">
+        {/* MLB 헤드샷 — onError로 깨진 이미지는 숨김 (placeholder 자리만 유지) */}
+        <img
+          src={headshotUrl(item.player_id)}
+          alt=""
+          loading="lazy"
+          className="h-14 w-14 shrink-0 rounded-full bg-white/5 object-cover"
+          onError={(e) => { (e.currentTarget as HTMLImageElement).style.visibility = "hidden"; }}
+        />
+
+        <div className="min-w-0 flex-1">
+          {/* 이름 + 등번호 */}
+          <div className="flex items-baseline gap-2">
+            <h3 className="truncate text-sm font-semibold text-white">{item.name}</h3>
+            {item.primary_number && (
+              <span className="text-xs text-white/40">#{item.primary_number}</span>
+            )}
+          </div>
+
+          {/* 포지션 · 팀 */}
+          <p className="mt-0.5 text-xs text-white/50">
+            {item.position ?? "—"} · {item.team ?? "—"}
+          </p>
+
+          {/* status 뱃지 */}
+          <span
+            className={`mt-2 inline-flex items-center rounded-md border px-2 py-0.5 text-[11px] font-medium ${tone}`}
+          >
+            {item.injury_status}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/home/InjuredPlayersStrip.tsx
+++ b/fe/src/features/home/InjuredPlayersStrip.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+import Modal from "../../components/ui/Modal";
+import type { InjuredPlayer } from "../../types/home";
+import InjuredPlayerCard from "./InjuredPlayerCard";
+
+/**
+ * InjuredPlayersStrip: HomePage의 부상자 섹션
+ * - 상위 3명 가로 카드 (Latest News 섹션과 같은 outer container 스타일)
+ * - "View all →" 클릭 시 전체 명단 popup
+ *
+ * 데이터: GET /api/players/injured (limit 없음 = 전체).
+ * - strip은 처음 3명만 slice
+ * - popup은 전체 리스트
+ * - 한 번만 fetch해서 두 곳 다 사용 (popup 클릭 시 추가 호출 없음)
+ */
+
+const ENDPOINT = "/api/players/injured";
+
+export default function InjuredPlayersStrip() {
+  const [players, setPlayers] = useState<InjuredPlayer[]>([]);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    fetch(ENDPOINT)
+      .then((r) => r.json())
+      .then((data: InjuredPlayer[]) => setPlayers(Array.isArray(data) ? data : []))
+      .catch(() => setPlayers([]));
+  }, []);
+
+  // 부상자가 0명이면 섹션 자체를 숨김 (빈 박스 보여주는 것보다 깔끔)
+  if (players.length === 0) return null;
+
+  const top3 = players.slice(0, 3);
+
+  return (
+    <>
+      {/* News 섹션과 동일한 outer container 스타일로 sibling 느낌 */}
+      <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+        <div className="flex items-end justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-bold text-white">Injured Players</h2>
+            <p className="mt-1 text-xs text-white/50">
+              Updated daily · sorted by player value
+            </p>
+          </div>
+          <button
+            onClick={() => setOpen(true)}
+            className="text-xs font-bold text-white/60 hover:text-white transition"
+          >
+            View all →
+          </button>
+        </div>
+
+        {/* 3카드 가로 (sm 이상에서는 3열, 모바일은 1열로 자연스럽게 떨어짐) */}
+        <div className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {top3.map((p) => (
+            <InjuredPlayerCard key={p.player_id} item={p} />
+          ))}
+        </div>
+      </section>
+
+      {/* View All popup — 같은 카드 컴포넌트로 전체 표시, 스크롤 가능 */}
+      <Modal
+        open={open}
+        title={`Injured Players (${players.length})`}
+        onClose={() => setOpen(false)}
+      >
+        <div className="grid max-h-[60vh] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2">
+          {players.map((p) => (
+            <InjuredPlayerCard key={p.player_id} item={p} />
+          ))}
+        </div>
+      </Modal>
+    </>
+  );
+}

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -8,6 +8,7 @@ import FadeIn from "../components/ui/FadeIn";          // 페이드 인 애니�
 import NewsCard from "../features/home/NewsCard";      // 뉴스 카드 컴포넌트
 import DraftSetupCard from "../features/home/DraftSetupCard"; // 드래프트 설정 카드 (로그인 시)
 import SignInCard from "../features/home/SignInCard";        // 로그인 유도 카드 (비로그인 시)
+import InjuredPlayersStrip from "../features/home/InjuredPlayersStrip"; // 부상 선수 strip + popup
 import type { NewsItem } from "../types/home";
 
 const MLB_RSS_URL = "https://sports.yahoo.com/mlb/rss/";
@@ -186,6 +187,11 @@ export default function HomePage() {
           {authed ? <DraftSetupCard /> : <SignInCard />}
         </FadeIn>
       </div>
+
+      {/* 부상 선수 섹션 — Latest News의 sibling 위치 (그리드 아래 full width) */}
+      <FadeIn delayMs={180}>
+        <InjuredPlayersStrip />
+      </FadeIn>
     </div>
   );
 }

--- a/fe/src/types/home.ts
+++ b/fe/src/types/home.ts
@@ -13,6 +13,20 @@ export type NewsItem = {
 };
 
 /**
+ * InjuredPlayer: HomePage Injured Players strip + popup에서 사용
+ * 백엔드 GET /api/players/injured 응답 형태와 1:1 매칭
+ */
+export type InjuredPlayer = {
+  player_id: number;       // MLB stable ID — headshot URL에 사용
+  name: string;
+  position?: string;       // OF / 3B / SP ...
+  team?: string;           // NYY / LAA ...
+  primary_number?: string; // jersey number (#)
+  injury_status: string;   // Day-To-Day / 10-Day IL / Out ...
+  player_value?: number;   // 0~100 fantasy value (정렬에만 사용)
+};
+
+/**
  * TopPlayer: 상위 선수 정보 (현재 사용되지 않지만 타입 정의만 유지)
  */
 export type TopPlayer = {


### PR DESCRIPTION
## What
Add an **Injured Players** section on the HomePage, sibling to Latest News.
- Strip with the top 3 injured stars (horizontal cards)
- "View all →" opens a popup showing the full list

## Backend
Uses [PPA-DUN-be#77](https://github.com/Ppa-Dun-project/PPA-DUN-be/pull/77) — \`GET /api/players/injured\`.
Strip and popup share a single fetch (no redundant network call).

## Files
- \`types/home.ts\` — add \`InjuredPlayer\` type
- \`features/home/InjuredPlayerCard.tsx\` (new) — single card with MLB headshot + status badge
- \`features/home/InjuredPlayersStrip.tsx\` (new) — section + Modal
- \`pages/HomePage.tsx\` — render strip below the news + side-card grid

## UX
- Same outer container / heading style as Latest News (sibling sections)
- Status color-coded: yellow (Day-To-Day), orange (10/15/7-Day IL), red (60-Day IL / Out)
- Section hidden when no injuries (no empty box)
- Reuses existing \`Modal\` component (ESC + overlay click to close)

## Related Issue
Closes #75