### PR TITLE
feature: pitcher data implementation #80

### DIFF
--- a/fe/src/features/draft/components/PlayerComparisonModal.tsx
+++ b/fe/src/features/draft/components/PlayerComparisonModal.tsx
@@ -16,11 +16,13 @@ type MetricDef = {
   getValue: (player: DraftPlayer) => number | null;
   formatValue: (value: number | null) => string;
   deltaDigits: number;
+  lowerIsBetter?: boolean;
+  comparable?: boolean;
 };
 
 type Trend = "up" | "down" | "equal" | "na";
 
-const METRICS: MetricDef[] = [
+const BATTER_METRICS: MetricDef[] = [
   {
     key: "avg",
     label: "AVG",
@@ -53,6 +55,49 @@ const METRICS: MetricDef[] = [
     formatValue: (value) => (value === null ? "-" : String(value)),
     deltaDigits: 0,
   },
+];
+
+const PITCHER_METRICS: MetricDef[] = [
+  {
+    key: "era",
+    label: "ERA",
+    getValue: (player) => player.era ?? null,
+    formatValue: (value) => (value === null ? "-" : value.toFixed(2)),
+    deltaDigits: 2,
+    lowerIsBetter: true,
+  },
+  {
+    key: "whip",
+    label: "WHIP",
+    getValue: (player) => player.whip ?? null,
+    formatValue: (value) => (value === null ? "-" : value.toFixed(3)),
+    deltaDigits: 3,
+    lowerIsBetter: true,
+  },
+  {
+    key: "ip",
+    label: "IP",
+    getValue: (player) => player.ip ?? null,
+    formatValue: (value) => (value === null ? "-" : value.toFixed(1)),
+    deltaDigits: 1,
+  },
+  {
+    key: "so",
+    label: "SO",
+    getValue: (player) => player.so ?? null,
+    formatValue: (value) => (value === null ? "-" : String(value)),
+    deltaDigits: 0,
+  },
+  {
+    key: "sv",
+    label: "SV",
+    getValue: (player) => player.sv ?? null,
+    formatValue: (value) => (value === null ? "-" : String(value)),
+    deltaDigits: 0,
+  },
+];
+
+const VALUE_METRICS: MetricDef[] = [
   {
     key: "ppa",
     label: "PPA-DUN Value",
@@ -69,10 +114,22 @@ const METRICS: MetricDef[] = [
   },
 ];
 
-function getTrend(value: number | null, opposite: number | null): Trend {
+function isPitcher(player: DraftPlayer) {
+  return player.playerType === "pitcher";
+}
+
+function metricsFor(playerA: DraftPlayer, playerB: DraftPlayer): MetricDef[] {
+  const aPitcher = isPitcher(playerA);
+  const bPitcher = isPitcher(playerB);
+  if (aPitcher && bPitcher) return [...PITCHER_METRICS, ...VALUE_METRICS];
+  if (!aPitcher && !bPitcher) return [...BATTER_METRICS, ...VALUE_METRICS];
+  return VALUE_METRICS;
+}
+
+function getTrend(value: number | null, opposite: number | null, lowerIsBetter = false): Trend {
   if (value === null || opposite === null) return "na";
-  if (value > opposite) return "up";
-  if (value < opposite) return "down";
+  if (value > opposite) return lowerIsBetter ? "down" : "up";
+  if (value < opposite) return lowerIsBetter ? "up" : "down";
   return "equal";
 }
 
@@ -142,9 +199,12 @@ function hasValidAiInputs(player: DraftPlayer): player is DraftPlayerWithValues 
 type AiRecommendRequest = {
   playerA: {
     name: string;
+    playerType: "batter" | "pitcher" | "two_way";
+    team: string;
+    positions: string[];
     ppaValue: number;
     recommendedBid: number;
-    stats: { avg: number | null; hr: number | null; rbi: number | null; sb: number | null };
+    stats: Record<string, number | null>;
   };
   playerB: AiRecommendRequest["playerA"];
 };
@@ -153,17 +213,31 @@ type AiRecommendResponse = {
   recommendation: string;
 };
 
-function toAiPayload(player: DraftPlayerWithValues) {
+function toAiPayload(player: DraftPlayerWithValues): AiRecommendRequest["playerA"] {
+  const stats: Record<string, number | null> = isPitcher(player)
+    ? {
+        era: player.era ?? null,
+        whip: player.whip ?? null,
+        ip: player.ip ?? null,
+        so: player.so ?? null,
+        sv: player.sv ?? null,
+        w: player.w ?? null,
+      }
+    : {
+        avg: player.avg ?? null,
+        hr: player.hr ?? null,
+        rbi: player.rbi ?? null,
+        sb: player.sb ?? null,
+      };
+
   return {
     name: player.name,
+    playerType: player.playerType,
+    team: player.team,
+    positions: player.positions,
     ppaValue: player.ppaValue,
     recommendedBid: player.recommendedBid,
-    stats: {
-      avg: player.avg ?? null,
-      hr: player.hr ?? null,
-      rbi: player.rbi ?? null,
-      sb: player.sb ?? null,
-    },
+    stats,
   };
 }
 
@@ -248,9 +322,10 @@ export default function PlayerComparisonModal({ open, playerA, playerB, onClose 
   const rows = useMemo(() => {
     if (!playerA || !playerB) return [];
 
-    return METRICS.map((metric) => {
+    return metricsFor(playerA, playerB).map((metric) => {
       const valueA = metric.getValue(playerA);
       const valueB = metric.getValue(playerB);
+      const comparable = metric.comparable ?? true;
       return {
         key: metric.key,
         label: metric.label,
@@ -258,12 +333,12 @@ export default function PlayerComparisonModal({ open, playerA, playerB, onClose 
         valueB,
         displayA: metric.formatValue(valueA),
         displayB: metric.formatValue(valueB),
-        deltaA: formatSignedDelta(valueA, valueB, metric.deltaDigits),
-        deltaB: formatSignedDelta(valueB, valueA, metric.deltaDigits),
-        trendA: getTrend(valueA, valueB),
-        trendB: getTrend(valueB, valueA),
-        barA: normalizedWidth(valueA, valueB),
-        barB: normalizedWidth(valueB, valueA),
+        deltaA: comparable ? formatSignedDelta(valueA, valueB, metric.deltaDigits) : "N/A",
+        deltaB: comparable ? formatSignedDelta(valueB, valueA, metric.deltaDigits) : "N/A",
+        trendA: comparable ? getTrend(valueA, valueB, metric.lowerIsBetter) : "na",
+        trendB: comparable ? getTrend(valueB, valueA, metric.lowerIsBetter) : "na",
+        barA: comparable ? normalizedWidth(valueA, valueB) : 100,
+        barB: comparable ? normalizedWidth(valueB, valueA) : 100,
       };
     });
   }, [playerA, playerB]);

--- a/fe/src/features/myteam/utils.ts
+++ b/fe/src/features/myteam/utils.ts
@@ -1,5 +1,25 @@
 import type { MyTeamPlayer, MyTeamPosFilter, MyTeamSort } from "../../types/myteam";
 
+function isPitcher(player: MyTeamPlayer) {
+  return player.playerType === "pitcher";
+}
+
+function rateSortValue(player: MyTeamPlayer) {
+  return isPitcher(player) ? (player.era == null ? 0 : -player.era) : player.avg;
+}
+
+function powerSortValue(player: MyTeamPlayer) {
+  return isPitcher(player) ? player.so ?? 0 : player.hr;
+}
+
+function productionSortValue(player: MyTeamPlayer) {
+  return isPitcher(player) ? player.w ?? 0 : player.rbi;
+}
+
+function speedSortValue(player: MyTeamPlayer) {
+  return isPitcher(player) ? player.sv ?? 0 : player.sb;
+}
+
 /**
  * 선수 목록 필터링
  * - 이름/팀명 검색 (대소문자 무시)
@@ -36,13 +56,13 @@ export function sortMyTeam(players: MyTeamPlayer[], sort: MyTeamSort): MyTeamPla
     case "cost_asc":
       return copy.sort((a, b) => a.cost - b.cost);
     case "avg_desc":
-      return copy.sort((a, b) => b.avg - a.avg);
+      return copy.sort((a, b) => rateSortValue(b) - rateSortValue(a));
     case "hr_desc":
-      return copy.sort((a, b) => b.hr - a.hr);
+      return copy.sort((a, b) => powerSortValue(b) - powerSortValue(a));
     case "rbi_desc":
-      return copy.sort((a, b) => b.rbi - a.rbi);
+      return copy.sort((a, b) => productionSortValue(b) - productionSortValue(a));
     case "sb_desc":
-      return copy.sort((a, b) => b.sb - a.sb);
+      return copy.sort((a, b) => speedSortValue(b) - speedSortValue(a));
     default:
       return copy;
   }

--- a/fe/src/features/players/components/PlayerInfoModal.tsx
+++ b/fe/src/features/players/components/PlayerInfoModal.tsx
@@ -5,28 +5,71 @@ import { formatPpa } from "../../../utils/playerValue";
 type Props = {
   open: boolean;
   playerId: number | null;
+  playerType?: PlayerType;
   onClose: () => void;
+};
+
+type PlayerType = "batter" | "pitcher";
+
+type BatterStats = {
+  avg: number;
+  pa: number;
+  hr: number;
+  ops: number;
+  rbi: number;
+  ab: number;
+  r: number;
+  h: number;
+  bb: number;
+  k: number;
+  sb: number;
+  cs: number;
+  obp: number;
+  slg: number;
+};
+
+type PitcherStats = {
+  w: number;
+  sv: number;
+  so: number;
+  era: number;
+  whip: number;
+  ip: number;
+  l: number;
+  g: number;
+  gs: number;
+  war: number;
+  fip: number;
+  h: number;
+  r: number;
+  er: number;
+  hr: number;
+  bb: number;
+  hbp: number;
+  bf: number;
+  era_plus: number;
+  h9: number;
+  hr9: number;
+  bb9: number;
+  so9: number;
+  so_bb: number;
 };
 
 type PlayerDetailResponse = {
   id: number;
+  playerType: PlayerType;
   name: string;
   age: number;
   height_in: number;
   weight_lb: number;
-  bats: string;
+  bats?: string | null;
   throws: string;
   team: string;
   positions: string[];
   valueScore: number;
   headshotUrl?: string | null;
-  stats: {
-    g: number;
-    pa: number;
-    hr: number;
-    ops: number;
-    ip: number;
-  };
+  batterStats?: BatterStats | null;
+  pitcherStats?: PitcherStats | null;
 };
 
 const HITTER_POSITIONS = new Set([
@@ -71,7 +114,7 @@ function initialsOf(name: string) {
   return `${first[0]}${second[0]}`.toUpperCase();
 }
 
-export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
+export default function PlayerInfoModal({ open, playerId, playerType = "batter", onClose }: Props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [detail, setDetail] = useState<PlayerDetailResponse | null>(null);
@@ -95,7 +138,11 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
       setError(null);
     });
 
-    apiGet<PlayerDetailResponse>(`/api/players/${playerId}`, undefined, controller.signal)
+    apiGet<PlayerDetailResponse>(
+      `/api/players/${playerId}`,
+      { playerType },
+      controller.signal
+    )
       .then((data) => {
         if (controller.signal.aborted) return;
         setDetail(data);
@@ -110,12 +157,15 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
       });
 
     return () => controller.abort();
-  }, [open, playerId]);
+  }, [open, playerId, playerType]);
 
   const twoWay = useMemo(() => {
     if (!detail) return false;
     return isTwoWayPlayer(detail.positions);
   }, [detail]);
+
+  const batterStats = detail?.batterStats ?? null;
+  const pitcherStats = detail?.pitcherStats ?? null;
 
   if (!open) return null;
 
@@ -186,7 +236,7 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
               <div className="grid grid-cols-2 gap-2 md:grid-cols-4">
                 {[
                   { label: "Age", value: String(detail.age) },
-                  { label: "Bats / Throws", value: `${detail.bats} / ${detail.throws}` },
+                  { label: detail.bats ? "Bats / Throws" : "Throws", value: detail.bats ? `${detail.bats} / ${detail.throws}` : detail.throws },
                   { label: "Height", value: formatHeight(detail.height_in) },
                   { label: "Weight", value: formatWeight(detail.weight_lb) },
                   { label: "Team", value: detail.team },
@@ -203,12 +253,17 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
             </section>
 
             <section>
-              <div className="mb-2 text-sm font-black uppercase tracking-wide text-white/55">Season Stats (Batting)</div>
+              <div className="mb-2 text-sm font-black uppercase tracking-wide text-white/55">
+                Season Stats ({detail.playerType === "pitcher" ? "Pitching" : "Batting"})
+              </div>
               <div className="overflow-x-auto rounded-xl border border-white/10 bg-[#0f1424]">
                 <table className="w-full min-w-[640px]">
                   <thead className="border-b border-white/10 bg-white/5 text-[11px] uppercase tracking-wide text-white/45">
                     <tr>
-                      {["G", "PA", "HR", "OPS", "IP"].map((col) => (
+                      {(detail.playerType === "pitcher"
+                        ? ["ERA", "WHIP", "IP", "SO", "SV"]
+                        : ["AVG", "PA", "HR", "OPS", "RBI"]
+                      ).map((col) => (
                         <th key={col} className="px-3 py-2 text-center font-black">
                           {col}
                         </th>
@@ -217,11 +272,25 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
                   </thead>
                   <tbody>
                     <tr className="text-center text-sm font-semibold text-white">
-                      <td className="px-3 py-2">{detail.stats.g}</td>
-                      <td className="px-3 py-2">{detail.stats.pa}</td>
-                      <td className="px-3 py-2 text-amber-300">{detail.stats.hr}</td>
-                      <td className="px-3 py-2 text-amber-300">{detail.stats.ops.toFixed(3)}</td>
-                      <td className="px-3 py-2">{detail.stats.ip.toFixed(1)}</td>
+                      {detail.playerType === "pitcher" && pitcherStats ? (
+                        <>
+                          <td className="px-3 py-2">{pitcherStats.era.toFixed(2)}</td>
+                          <td className="px-3 py-2">{pitcherStats.whip.toFixed(3)}</td>
+                          <td className="px-3 py-2">{pitcherStats.ip.toFixed(1)}</td>
+                          <td className="px-3 py-2 text-amber-300">{pitcherStats.so}</td>
+                          <td className="px-3 py-2 text-amber-300">{pitcherStats.sv}</td>
+                        </>
+                      ) : batterStats ? (
+                        <>
+                          <td className="px-3 py-2">{batterStats.avg.toFixed(3)}</td>
+                          <td className="px-3 py-2">{batterStats.pa}</td>
+                          <td className="px-3 py-2 text-amber-300">{batterStats.hr}</td>
+                          <td className="px-3 py-2 text-amber-300">{batterStats.ops.toFixed(3)}</td>
+                          <td className="px-3 py-2">{batterStats.rbi}</td>
+                        </>
+                      ) : (
+                        <td className="px-3 py-2" colSpan={5}>-</td>
+                      )}
                     </tr>
                   </tbody>
                 </table>
@@ -243,7 +312,11 @@ export default function PlayerInfoModal({ open, playerId, onClose }: Props) {
                     This player has both hitter and pitcher positions: {detail.positions.join(", ")}
                   </div>
                   <div className="mt-2 text-white/75">
-                    Pitching workload (IP): {detail.stats.ip.toFixed(1)}
+                    {detail.playerType === "pitcher" && pitcherStats
+                      ? `Pitching workload (IP): ${pitcherStats.ip.toFixed(1)}`
+                      : batterStats
+                        ? `Run production (RBI): ${batterStats.rbi}`
+                        : "No role-specific stats available"}
                   </div>
                 </div>
               </section>

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -93,13 +93,48 @@ function matchesPositionFilter(
   return normalized.includes(filter);
 }
 
+function isPitcherOnly(player: DraftPlayerPublic): boolean {
+  return player.playerType === "pitcher";
+}
+
+function formatNumber(value: number | null | undefined, digits: number) {
+  if (value === null || value === undefined) return "-";
+  return value.toFixed(digits);
+}
+
+function formatDraftStatSummary(player: DraftPlayerPublic) {
+  if (isPitcherOnly(player)) {
+    return `ERA ${formatNumber(player.era, 2)} | SO ${player.so ?? "-"} | W ${player.w ?? "-"} | SV ${player.sv ?? "-"}`;
+  }
+  return `AVG ${formatAvg(player.avg)} | HR ${player.hr ?? "-"} | RBI ${player.rbi ?? "-"} | SB ${player.sb ?? "-"}`;
+}
+
+function primaryRateSortValue(player: DraftPlayerPublic) {
+  if (isPitcherOnly(player)) {
+    return player.era === null || player.era === undefined ? 0 : -player.era;
+  }
+  return player.avg ?? 0;
+}
+
+function powerSortValue(player: DraftPlayerPublic) {
+  return isPitcherOnly(player) ? player.so ?? 0 : player.hr ?? 0;
+}
+
+function productionSortValue(player: DraftPlayerPublic) {
+  return isPitcherOnly(player) ? player.w ?? 0 : player.rbi ?? 0;
+}
+
+function speedSortValue(player: DraftPlayerPublic) {
+  return isPitcherOnly(player) ? player.sv ?? 0 : player.sb ?? 0;
+}
+
 const DEFAULT_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
   { value: "score_desc", label: "By Score" },
   { value: "cost_desc", label: "By Draft Cost" },
-  { value: "avg_desc", label: "By AVG" },
-  { value: "hr_desc", label: "By HR" },
-  { value: "rbi_desc", label: "By RBI" },
-  { value: "sb_desc", label: "By SB" },
+  { value: "avg_desc", label: "By AVG/ERA" },
+  { value: "hr_desc", label: "By HR/SO" },
+  { value: "rbi_desc", label: "By RBI/W" },
+  { value: "sb_desc", label: "By SB/SV" },
 ];
 
 // 공개 /api/draft/players — PPA 값 / 추천 bid 없이 전체 선수 목록만
@@ -203,6 +238,7 @@ export default function DraftPage() {
   const [compareBId, setCompareBId] = useState<string | null>(null);
   const [comparisonOpen, setComparisonOpen] = useState(false);
   const [profilePlayerId, setProfilePlayerId] = useState<number | null>(null);
+  const [profilePlayerType, setProfilePlayerType] = useState<"batter" | "pitcher">("batter");
 
   const [addTarget, setAddTarget] = useState<DraftPlayer | null>(null);
   const [takenTarget, setTakenTarget] = useState<DraftPlayer | null>(null);
@@ -246,13 +282,13 @@ export default function DraftPage() {
         case "cost_desc":
           return (b.recommendedBid ?? 0) - (a.recommendedBid ?? 0);
         case "avg_desc":
-          return (b.avg ?? 0) - (a.avg ?? 0);
+          return primaryRateSortValue(b) - primaryRateSortValue(a);
         case "hr_desc":
-          return (b.hr ?? 0) - (a.hr ?? 0);
+          return powerSortValue(b) - powerSortValue(a);
         case "rbi_desc":
-          return (b.rbi ?? 0) - (a.rbi ?? 0);
+          return productionSortValue(b) - productionSortValue(a);
         case "sb_desc":
-          return (b.sb ?? 0) - (a.sb ?? 0);
+          return speedSortValue(b) - speedSortValue(a);
         case "score_desc":
         default:
           return (b.ppaValue ?? 0) - (a.ppaValue ?? 0);
@@ -499,13 +535,14 @@ export default function DraftPage() {
     setComparisonOpen(false);
   };
 
-  const openPlayerInfo = (rawPlayerId: string) => {
+  const openPlayerInfo = (rawPlayerId: string, playerType: "batter" | "pitcher" | "two_way") => {
     const parsed = Number(rawPlayerId);
     if (!Number.isFinite(parsed)) {
       setError("Invalid player id");
       return;
     }
     setProfilePlayerId(parsed);
+    setProfilePlayerType(playerType === "pitcher" ? "pitcher" : "batter");
   };
 
   const closePlayerInfo = () => {
@@ -834,7 +871,7 @@ export default function DraftPage() {
                         {selectedA.positions.join("/")} - {selectedA.team} - ${selectedA.recommendedBid ?? "—"}
                       </div>
                       <div className="mt-1 text-[10px] text-white/55">
-                        AVG {formatAvg(selectedA.avg)} | HR {selectedA.hr ?? "-"} | RBI {selectedA.rbi ?? "-"} | SB {selectedA.sb ?? "-"}
+                        {formatDraftStatSummary(selectedA)}
                       </div>
                     </>
                   ) : (
@@ -866,7 +903,7 @@ export default function DraftPage() {
                         {selectedB.positions.join("/")} - {selectedB.team} - ${selectedB.recommendedBid ?? "—"}
                       </div>
                       <div className="mt-1 text-[10px] text-white/55">
-                        AVG {formatAvg(selectedB.avg)} | HR {selectedB.hr ?? "-"} | RBI {selectedB.rbi ?? "-"} | SB {selectedB.sb ?? "-"}
+                        {formatDraftStatSummary(selectedB)}
                       </div>
                     </>
                   ) : (
@@ -907,10 +944,10 @@ export default function DraftPage() {
             <div>Pos</div>
             <div>Draft Cost</div>
             <div>Team</div>
-            <div>AVG</div>
-            <div>HR</div>
-            <div>RBI</div>
-            <div>SB</div>
+            <div>AVG/ERA</div>
+            <div>HR/SO</div>
+            <div>RBI/W</div>
+            <div>SB/SV</div>
             <div>PPA-DUN Value</div>
             <div>Action</div>
             <div>Compare</div>
@@ -953,7 +990,7 @@ export default function DraftPage() {
                     <div>
                       <button
                         type="button"
-                        onClick={() => openPlayerInfo(player.id)}
+                        onClick={() => openPlayerInfo(player.id, player.playerType)}
                         className="rounded-md border border-transparent px-2 py-1 -mx-2 -my-1 font-semibold text-white transition hover:border-white/35 hover:bg-white/5 hover:text-amber-200 focus-visible:border-white/45 focus-visible:bg-white/10 focus-visible:outline-none"
                       >
                         {player.name}
@@ -979,10 +1016,18 @@ export default function DraftPage() {
                       </span>
                     </div>
 
-                    <div className="text-white/70">{formatAvg(player.avg)}</div>
-                    <div className="font-semibold text-amber-300">{player.hr ?? "-"}</div>
-                    <div className="text-white/70">{player.rbi ?? "-"}</div>
-                    <div className="font-semibold text-amber-300">{player.sb ?? "-"}</div>
+                    <div className="text-white/70">
+                      {isPitcherOnly(player) ? formatNumber(player.era, 2) : formatAvg(player.avg)}
+                    </div>
+                    <div className="font-semibold text-amber-300">
+                      {isPitcherOnly(player) ? player.so ?? "-" : player.hr ?? "-"}
+                    </div>
+                    <div className="text-white/70">
+                      {isPitcherOnly(player) ? player.w ?? "-" : player.rbi ?? "-"}
+                    </div>
+                    <div className="font-semibold text-amber-300">
+                      {isPitcherOnly(player) ? player.sv ?? "-" : player.sb ?? "-"}
+                    </div>
 
                     <div className={`font-black ${ppaValueClass(player.ppaValue, { authed })}`}>
                       {formatPpa(player.ppaValue)}
@@ -1092,6 +1137,7 @@ export default function DraftPage() {
       <PlayerInfoModal
         open={profilePlayerId !== null}
         playerId={profilePlayerId}
+        playerType={profilePlayerType}
         onClose={closePlayerInfo}
       />
 

--- a/fe/src/pages/MyTeamPage.tsx
+++ b/fe/src/pages/MyTeamPage.tsx
@@ -49,15 +49,24 @@ const POSITION_FILTERS: MyTeamPosFilter[] = [
 const SORT_OPTIONS: { value: MyTeamSort; label: string }[] = [
   { value: "score_desc", label: "By Score" },
   { value: "cost_desc", label: "By Value $" },
-  { value: "avg_desc", label: "By AVG" },
-  { value: "hr_desc", label: "By HR" },
-  { value: "rbi_desc", label: "By RBI" },
-  { value: "sb_desc", label: "By SB" },
+  { value: "avg_desc", label: "By AVG/ERA" },
+  { value: "hr_desc", label: "By HR/SO" },
+  { value: "rbi_desc", label: "By RBI/W" },
+  { value: "sb_desc", label: "By SB/SV" },
 ];
 
 // 테이블 컬럼 그리드 정의 (헤더와 각 행에서 공유)
 const TABLE_GRID_COLS =
   "grid-cols-[1.8fr_.6fr_.6fr_.7fr_.7fr_.7fr_.7fr_.7fr_.9fr]";
+
+function isPitcher(player: MyTeamPlayer) {
+  return player.playerType === "pitcher";
+}
+
+function formatNumber(value: number | null | undefined, digits: number) {
+  if (value === null || value === undefined) return "-";
+  return value.toFixed(digits);
+}
 
 export default function MyTeamPage() {
   // URL ?sessionId — 소스 오브 트루스. 새로고침/공유 후에도 같은 세션을 보여주기 위함.
@@ -86,6 +95,7 @@ export default function MyTeamPage() {
 
   // 선수 정보 모달 상태 (선택된 선수 ID)
   const [profilePlayerId, setProfilePlayerId] = useState<number | null>(null);
+  const [profilePlayerType, setProfilePlayerType] = useState<"batter" | "pitcher">("batter");
 
   // ── 1단계: 세션 목록 조회 + sessionId 결정 ──
   // - URL ?sessionId 가 사용자 소유 세션 중 하나면 그 값을 사용 (새로고침/공유 케이스)
@@ -291,10 +301,10 @@ export default function MyTeamPage() {
               <div>Pos</div>
               <div>$</div>
               <div>Team</div>
-              <div>AVG</div>
-              <div>HR</div>
-              <div>RBI</div>
-              <div>SB</div>
+              <div>AVG/ERA</div>
+              <div>HR/SO</div>
+              <div>RBI/W</div>
+              <div>SB/SV</div>
               <div className="text-right">PPA-DUN Value</div>
             </div>
 
@@ -323,7 +333,10 @@ export default function MyTeamPage() {
                   <div>
                     <button
                       type="button"
-                      onClick={() => setProfilePlayerId(Number(player.id))}
+                      onClick={() => {
+                        setProfilePlayerId(Number(player.id));
+                        setProfilePlayerType(player.playerType);
+                      }}
                       className="rounded-md border border-transparent px-2 py-1 -mx-2 -my-1 font-semibold text-white transition hover:border-white/35 hover:bg-white/5 hover:text-amber-200 focus-visible:border-white/45 focus-visible:bg-white/10 focus-visible:outline-none"
                     >
                       {player.name}
@@ -348,10 +361,18 @@ export default function MyTeamPage() {
                   </div>
 
                   {/* 스탯 */}
-                  <div className="text-white/70">{formatAvg(player.avg)}</div>
-                  <div className="font-semibold text-amber-300">{player.hr ?? "-"}</div>
-                  <div className="text-white/70">{player.rbi ?? "-"}</div>
-                  <div className="font-semibold text-amber-300">{player.sb ?? "-"}</div>
+                  <div className="text-white/70">
+                    {isPitcher(player) ? formatNumber(player.era, 2) : formatAvg(player.avg)}
+                  </div>
+                  <div className="font-semibold text-amber-300">
+                    {isPitcher(player) ? player.so ?? "-" : player.hr ?? "-"}
+                  </div>
+                  <div className="text-white/70">
+                    {isPitcher(player) ? player.w ?? "-" : player.rbi ?? "-"}
+                  </div>
+                  <div className="font-semibold text-amber-300">
+                    {isPitcher(player) ? player.sv ?? "-" : player.sb ?? "-"}
+                  </div>
 
                   {/* PPA-DUN 가치 점수 (10점 이상이면 발광 효과) */}
                   <div className={`text-right text-sm font-black ${ppaValueClass(player.ppaValue)}`}>
@@ -369,6 +390,7 @@ export default function MyTeamPage() {
       <PlayerInfoModal
         open={profilePlayerId !== null}
         playerId={profilePlayerId}
+        playerType={profilePlayerType}
         onClose={() => setProfilePlayerId(null)}
       />
     </div>

--- a/fe/src/pages/PlayerDetailPage.tsx
+++ b/fe/src/pages/PlayerDetailPage.tsx
@@ -7,23 +7,31 @@ import { formatPpa } from "../utils/playerValue";
 
 type PlayerDetailResponse = {
   id: number;
+  playerType: "batter" | "pitcher";
   name: string;
   age: number;
   height_in: number;
   weight_lb: number;
-  bats: string;
+  bats?: string | null;
   throws: string;
   team: string;
   positions: string[];
   valueScore: number;
   headshotUrl?: string | null;
-  stats: {
-    g: number;
+  batterStats?: {
+    avg: number;
     pa: number;
     hr: number;
     ops: number;
+    rbi: number;
+  } | null;
+  pitcherStats?: {
+    era: number;
+    whip: number;
     ip: number;
-  };
+    so: number;
+    sv: number;
+  } | null;
 };
 
 export default function PlayerDetailPage() {
@@ -111,17 +119,29 @@ export default function PlayerDetailPage() {
 
       <div className="mt-6 grid gap-3 text-sm text-white/80 md:grid-cols-2">
         <div>Age: {player.age}</div>
-        <div>B/T: {player.bats}/{player.throws}</div>
+        <div>{player.bats ? `B/T: ${player.bats}/${player.throws}` : `Throws: ${player.throws}`}</div>
         <div>Height: {player.height_in} in</div>
         <div>Weight: {player.weight_lb} lb</div>
       </div>
 
       <div className="mt-6 grid grid-cols-2 gap-3 rounded-2xl border border-white/10 bg-black/25 p-4 text-sm text-white/80 md:grid-cols-5">
-        <div>G: {player.stats.g}</div>
-        <div>PA: {player.stats.pa}</div>
-        <div>HR: {player.stats.hr}</div>
-        <div>OPS: {player.stats.ops.toFixed(3)}</div>
-        <div>IP: {player.stats.ip.toFixed(1)}</div>
+        {player.playerType === "pitcher" && player.pitcherStats ? (
+          <>
+            <div>ERA: {player.pitcherStats.era.toFixed(2)}</div>
+            <div>WHIP: {player.pitcherStats.whip.toFixed(3)}</div>
+            <div>IP: {player.pitcherStats.ip.toFixed(1)}</div>
+            <div>SO: {player.pitcherStats.so}</div>
+            <div>SV: {player.pitcherStats.sv}</div>
+          </>
+        ) : player.batterStats ? (
+          <>
+            <div>AVG: {player.batterStats.avg.toFixed(3)}</div>
+            <div>PA: {player.batterStats.pa}</div>
+            <div>HR: {player.batterStats.hr}</div>
+            <div>OPS: {player.batterStats.ops.toFixed(3)}</div>
+            <div>RBI: {player.batterStats.rbi}</div>
+          </>
+        ) : null}
       </div>
 
       <Link to="/draft" className="mt-6 inline-block text-sm font-black text-white/70 hover:text-white">

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -5,12 +5,19 @@
 export type DraftPlayerPublic = {
   id: string;
   name: string;
+  playerType: "batter" | "pitcher" | "two_way";
   team: string;                  // MLB 팀 약어 (예: "NYY")
   positions: string[];           // 포지션 배열 (예: ["OF", "DH"])
   avg: number | null;            // 타율
   hr: number | null;             // 홈런
   rbi: number | null;            // 타점
   sb: number | null;             // 도루
+  w: number | null;
+  sv: number | null;
+  so: number | null;
+  era: number | null;
+  whip: number | null;
+  ip: number | null;
 };
 
 /**

--- a/fe/src/types/myteam.ts
+++ b/fe/src/types/myteam.ts
@@ -5,6 +5,7 @@
 export type MyTeamPlayer = {
   id: string;
   name: string;
+  playerType: "batter" | "pitcher";
   pos: string;            // 포지션 (단일)
   cost: number;           // 낙찰가 ($)
   team: string;           // MLB 팀
@@ -12,6 +13,12 @@ export type MyTeamPlayer = {
   hr: number;             // 홈런
   rbi: number;            // 타점
   sb: number;             // 도루
+  w?: number | null;
+  sv?: number | null;
+  so?: number | null;
+  era?: number | null;
+  whip?: number | null;
+  ip?: number | null;
   ppaValue: number;       // PPA-DUN 점수
 };
 


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Added pitcher-aware UI support across draft, my team, and player detail views, including pitcher-specific stats such as ERA, WHIP, IP, SO, W, and SV.
- Updated player comparison and AI recommendation payloads to use role-appropriate stats for batters and pitchers.

## Why
<!-- Why did you do it? -->
- The frontend needed to reflect the backend/API split between batter and pitcher data while keeping existing draft and roster workflows consistent.

## Related Issue
<!-- e.g. #123 -->
- #80 