### PR TITLE
feat(home, draft): move Draft Setup into a modal on the Draft page

### DIFF
--- a/fe/src/components/ui/Modal.tsx
+++ b/fe/src/components/ui/Modal.tsx
@@ -21,15 +21,15 @@ export default function Modal({ open, title, onClose, children, footer }: Props)
   if (!open) return null;
 
   return (
-    <div className="fixed inset-0 z-50">
-      {/* overlay */}
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      {/* overlay — fixed so it stays put while the panel scrolls */}
       <button
         aria-label="Close modal"
-        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        className="fixed inset-0 bg-black/70 backdrop-blur-sm"
         onClick={onClose}
       />
-      {/* panel */}
-      <div className="relative mx-auto mt-20 w-[92%] max-w-2xl rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl">
+      {/* panel — vertical margin lets long content scroll within the viewport */}
+      <div className="relative mx-auto my-10 w-[92%] max-w-2xl rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl">
         <div className="flex items-start justify-between gap-4">
           <div>
             {title && <h3 className="text-lg font-semibold text-white">{title}</h3>}

--- a/fe/src/features/auth/LoginPromptModal.tsx
+++ b/fe/src/features/auth/LoginPromptModal.tsx
@@ -1,0 +1,28 @@
+import Modal from "../../components/ui/Modal";
+import { useGoogleSignIn } from "../../lib/googleAuth";
+
+type Props = {
+  open: boolean;
+  onClose: () => void;
+  onAuthSuccess?: () => void;
+};
+
+// 비로그인 유저가 보호된 액션(예: Start Your Draft)을 시도했을 때 띄우는 모달.
+// 구글 로그인 성공 시 onAuthSuccess 콜백 실행 후 모달을 닫는다.
+export default function LoginPromptModal({ open, onClose, onAuthSuccess }: Props) {
+  const buttonRef = useGoogleSignIn(() => {
+    onAuthSuccess?.();
+    onClose();
+  });
+
+  return (
+    <Modal open={open} title="Sign in to continue" onClose={onClose}>
+      <div className="flex flex-col items-center gap-4">
+        <p className="text-center text-sm text-white/70">
+          Sign in with Google to start and save your draft.
+        </p>
+        <div ref={buttonRef} className="w-full max-w-xs" />
+      </div>
+    </Modal>
+  );
+}

--- a/fe/src/features/home/DraftSetupCard.tsx
+++ b/fe/src/features/home/DraftSetupCard.tsx
@@ -5,6 +5,22 @@ import { isAuthed } from "../../lib/auth";
 
 type LeagueType = "standard" | "lite" | "custom";
 
+// 모달 안에서 재사용할 때 onSubmit 으로 동작을 override 한다.
+// (생략 시 기본 동작: localStorage 저장 + /draft?setup=1 로 navigate)
+// embedded=true 면 카드 wrapper(section, border, padding) 없이 폼 내용만 그린다.
+export type DraftSetupConfig = {
+  myTeamName: string;
+  opponentsCount: number;
+  oppTeamNames: string[];
+  leagueType: LeagueType;
+  budget: number;
+  rosterPlayers: number;
+};
+type Props = {
+  onSubmit?: (config: DraftSetupConfig) => void;
+  embedded?: boolean;
+};
+
 const presets = {
   standard: { label: "Standard", budget: 260, players: 12, opponents: 11, note: "$260 / 12 players / 12 teams" },
   lite: { label: "Lite", budget: 200, players: 10, opponents: 9, note: "$200 / 10 players / 10 teams" },
@@ -45,7 +61,7 @@ const ROSTER_MIN = 1;
 const ROSTER_MAX = 12;
 const BUDGET_MIN = 1;
 
-export default function DraftSetupCard() {
+export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {}) {
   const navigate = useNavigate();
   const authed = isAuthed();
 
@@ -115,8 +131,7 @@ export default function DraftSetupCard() {
   };
 
   const onStartDraft = () => {
-    // 옵션 A: 서버에 즉시 세션을 만들지 않는다. 폼 값을 ppadun_unsaved_draft 에 저장하고 /draft 로 이동.
-    const config = {
+    const config: DraftSetupConfig = {
       myTeamName: myTeam.trim() || "My Team",
       opponentsCount,
       oppTeamNames: oppTeamNames.map((name, i) => name.trim() || `Opponent ${i + 1}`),
@@ -125,17 +140,22 @@ export default function DraftSetupCard() {
       rosterPlayers: computed.players,
     };
 
+    // 모달 컨텍스트에서는 onSubmit 으로 부모(DraftPage)가 state 를 직접 갱신한다.
+    if (onSubmit) {
+      onSubmit(config);
+      return;
+    }
+
+    // 기본 동작: ppadun_unsaved_draft 에 저장하고 /draft 로 이동.
     localStorage.setItem(
       "ppadun_unsaved_draft",
       JSON.stringify({ config, picks: [] })
     );
-
-    const target = "/draft?setup=1";
-    navigate(target);
+    navigate("/draft?setup=1");
   };
 
-  return (
-    <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+  const body = (
+    <>
       <div className="flex items-center justify-center gap-3">
         <div className="h-12 w-12 overflow-hidden rounded-2xl">
           <img src={logo} alt="Logo" className="h-full w-full object-cover" />
@@ -304,6 +324,13 @@ export default function DraftSetupCard() {
           </div>
         )}
       </div>
+    </>
+  );
+
+  if (embedded) return body;
+  return (
+    <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+      {body}
     </section>
   );
 }

--- a/fe/src/features/home/InjuredPlayersStrip.tsx
+++ b/fe/src/features/home/InjuredPlayersStrip.tsx
@@ -50,8 +50,8 @@ export default function InjuredPlayersStrip() {
           </button>
         </div>
 
-        {/* 3카드 가로 (sm 이상에서는 3열, 모바일은 1열로 자연스럽게 떨어짐) */}
-        <div className="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {/* 우측 1/3 컬럼에 들어가므로 항상 세로 1열 stack */}
+        <div className="mt-5 grid grid-cols-1 gap-4">
           {top3.map((p) => (
             <InjuredPlayerCard key={p.player_id} item={p} />
           ))}

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -55,6 +55,9 @@ import TakenBidModal from "../features/draft/components/TakenBidModal";
 import PlayerComparisonModal from "../features/draft/components/PlayerComparisonModal";
 import PlayerInfoModal from "../features/players/components/PlayerInfoModal";
 import Pagination from "../features/players/components/Pagination";
+import Modal from "../components/ui/Modal";
+import DraftSetupCard, { type DraftSetupConfig } from "../features/home/DraftSetupCard";
+import LoginPromptModal from "../features/auth/LoginPromptModal";
 
 const PAGE_SIZE = 30;
 
@@ -243,8 +246,11 @@ export default function DraftPage() {
   const isLoadedMode = sessionId !== null && Number.isFinite(sessionId);
 
   const [searchParams] = useSearchParams();
-  const useStoredDraftConfig = searchParams.get("setup") === "1";
   const draftRoomTopRef = useRef<HTMLDivElement | null>(null); // Scroll target after draft pick
+
+  // "Start Your Draft" 버튼이 띄우는 setup / 로그인 유도 모달.
+  const [setupModalOpen, setSetupModalOpen] = useState(false);
+  const [loginModalOpen, setLoginModalOpen] = useState(false);
 
   // 핵심 드래프트 state — 마운트 시 한 번 채워지고 이후 모든 픽 변경은 React state 만 갱신.
   const [config, setConfig] = useState<DraftConfigServer | null>(null);
@@ -406,6 +412,56 @@ export default function DraftPage() {
     setTakenTarget(null);
   };
 
+  // Start Your Draft 모달에서 입력한 config 로 page state 를 갱신.
+  // localStorage 도 함께 저장해 새로고침해도 resume 되도록 한다.
+  const handleSetupSubmit = (next: DraftSetupConfig) => {
+    const config: DraftConfigServer = {
+      leagueType: next.leagueType,
+      budget: next.budget,
+      rosterPlayers: next.rosterPlayers,
+      myTeamName: next.myTeamName,
+      opponentsCount: next.opponentsCount,
+      oppTeamNames: next.oppTeamNames,
+    };
+    try {
+      localStorage.setItem(
+        UNSAVED_DRAFT_KEY,
+        JSON.stringify({ config, picks: [] } satisfies UnsavedDraft)
+      );
+    } catch {
+      // 쿼터 초과 등은 조용히 무시.
+    }
+    setConfig(config);
+    setTeams(buildTeamsFromConfig(config));
+    setPicks([]);
+    setHasDraftConfig(true);
+    setSetupModalOpen(false);
+  };
+
+  // 비로그인이면 로그인 모달, 로그인 상태면 setup 모달.
+  const openStartDraft = () => {
+    if (authed) {
+      setSetupModalOpen(true);
+    } else {
+      setLoginModalOpen(true);
+    }
+  };
+
+  // 진행 중인 미저장 draft 폐기 — localStorage 비우고 player browser 상태로 복귀.
+  // 저장된 세션(isLoadedMode)은 이 버튼 자체가 노출되지 않으므로 분기 필요 없음.
+  const handleDiscardDraft = () => {
+    if (!window.confirm("Discard the current draft? This cannot be undone.")) return;
+    try {
+      localStorage.removeItem(UNSAVED_DRAFT_KEY);
+    } catch {
+      // ignore
+    }
+    setConfig(DEFAULT_DRAFT_CONFIG);
+    setTeams(buildTeamsFromConfig(DEFAULT_DRAFT_CONFIG));
+    setPicks([]);
+    setHasDraftConfig(false);
+  };
+
   // 마운트 분기:
   //  - sessionId 있음(로드 모드): GET /api/draft/sessions/{id}. 404 → 홈.
   //  - setup=1 있음(새 드래프트 모드): localStorage["ppadun_unsaved_draft"] 읽음.
@@ -439,16 +495,14 @@ export default function DraftPage() {
       return () => controller.abort();
     }
 
-    // 미저장 모드 — Draft Setup에서 온 경우에만 localStorage 설정을 사용한다.
-    // Navbar/direct URL 진입은 player browser로 취급해 이전 unsaved draft를 자동 복원하지 않는다.
+    // 미저장 모드 — localStorage에 unsaved draft가 있으면 자동 resume.
+    // 없으면 default config로 player browser 모드 (Start Your Draft 버튼 노출).
     let parsed: UnsavedDraft | null = null;
-    if (useStoredDraftConfig) {
-      try {
-        const raw = localStorage.getItem(UNSAVED_DRAFT_KEY);
-        if (raw) parsed = JSON.parse(raw) as UnsavedDraft;
-      } catch {
-        parsed = null;
-      }
+    try {
+      const raw = localStorage.getItem(UNSAVED_DRAFT_KEY);
+      if (raw) parsed = JSON.parse(raw) as UnsavedDraft;
+    } catch {
+      parsed = null;
     }
 
     const ready: UnsavedDraft = parsed?.config
@@ -462,7 +516,7 @@ export default function DraftPage() {
       setSessionName(null);
       setBootstrapped(true);
     });
-  }, [isLoadedMode, navigate, sessionId, useStoredDraftConfig]);
+  }, [isLoadedMode, navigate, sessionId]);
 
   // 미저장 모드에서 picks 가 바뀔 때마다 localStorage 에도 sync — 새로고침 보호.
   useEffect(() => {
@@ -779,6 +833,16 @@ export default function DraftPage() {
           </div>
 
           <div className="flex items-center gap-2">
+            {hasDraftConfig && !isLoadedMode && (
+              <button
+                type="button"
+                onClick={handleDiscardDraft}
+                className="rounded-2xl border border-rose-400/30 bg-rose-500/10 px-4 py-3 text-sm font-black text-rose-200 transition hover:bg-rose-500/20"
+                title="Discard the current unsaved draft and start over"
+              >
+                Discard
+              </button>
+            )}
             {authed && (
               <>
                 {hasDraftConfig && (
@@ -826,17 +890,22 @@ export default function DraftPage() {
               onRemovePick={handleRemovePick}
             />
           ) : (
-            <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
-              <div className="text-lg font-black text-white">
-                {authed ? "Default View" : "Guest View"}
+            <section className="rounded-3xl border border-white/10 bg-white/5 p-8 text-center">
+              <div className="text-2xl font-black text-white">
+                Ready to draft?
               </div>
               <div className="mt-2 text-sm text-white/60">
                 {authed
-                  ? "No saved draft session yet. Start from Draft Setup to create one."
-                  : hasDraftConfig
-                  ? "Sign in to use the live draft room board and Add / Taken actions."
-                  : "Start from Draft Setup to create a live draft board."}
+                  ? "Set up your league to start the live draft board."
+                  : "Sign in and set up your league to start the live draft board."}
               </div>
+              <button
+                type="button"
+                onClick={openStartDraft}
+                className="mt-6 inline-flex items-center justify-center rounded-2xl bg-white px-8 py-4 text-base font-black text-black transition hover:-translate-y-px hover:bg-white/90 active:translate-y-0"
+              >
+                Start Your Draft
+              </button>
             </section>
           )}
         </div>
@@ -1324,6 +1393,19 @@ export default function DraftPage() {
         </div>
       )}
 
+      <Modal
+        open={setupModalOpen}
+        title="Start Your Draft"
+        onClose={() => setSetupModalOpen(false)}
+      >
+        <DraftSetupCard embedded onSubmit={handleSetupSubmit} />
+      </Modal>
+
+      <LoginPromptModal
+        open={loginModalOpen}
+        onClose={() => setLoginModalOpen(false)}
+        onAuthSuccess={() => setSetupModalOpen(true)}
+      />
     </div>
   );
 }

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -6,8 +6,6 @@ import { useNavigate } from "react-router-dom";
 // 공통 UI 컴포넌트
 import FadeIn from "../components/ui/FadeIn";          // 페이드 인 애니메이션 래퍼
 import NewsCard from "../features/home/NewsCard";      // 뉴스 카드 컴포넌트
-import DraftSetupCard from "../features/home/DraftSetupCard"; // 드래프트 설정 카드 (로그인 시)
-import SignInCard from "../features/home/SignInCard";        // 로그인 유도 카드 (비로그인 시)
 import InjuredPlayersStrip from "../features/home/InjuredPlayersStrip"; // 부상 선수 strip + popup
 import type { NewsItem } from "../types/home";
 
@@ -33,18 +31,15 @@ const extractImageUrl = (html: string | undefined): string | undefined =>
 
 // 히어로 배너 배경 이미지
 import baseballImg from "../assets/Baseball.jpg";
-// 로그인 상태 실시간 추적 훅
-import { useAuth } from "../lib/auth";
 
 /**
  * HomePage: 랜딩 페이지
  * - 상단: 히어로 배너 + 검색창
  * - 좌측: 최신 뉴스 카드 3개
- * - 우측: 비로그인 → 로그인 유도 카드 / 로그인 → 드래프트 설정 카드
+ * - 우측: 부상 선수 명단
  */
 export default function HomePage() {
   const navigate = useNavigate();
-  const authed = useAuth();                    // 로그인 상태 (실시간 반영)
   const [query, setQuery] = useState("");      // 히어로 검색창 입력값
   const [news, setNews] = useState<NewsItem[]>([]);
 
@@ -147,11 +142,11 @@ export default function HomePage() {
         </section>
       </FadeIn>
 
-      {/* 뉴스 + 사이드 카드 2열 그리드 */}
+      {/* 뉴스 + 부상 선수 2열 그리드 */}
       {/* grid-cols-1: 기본 1열 / lg:grid-cols-3: 큰 화면에서 3열 */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        {/* 뉴스 + 부상자 섹션 (3열 중 2열 차지, 세로 stack) */}
-        <FadeIn className="space-y-6 lg:col-span-2" delayMs={60}>
+        {/* 좌측 뉴스 섹션 (3열 중 2열 차지) */}
+        <FadeIn className="lg:col-span-2" delayMs={60}>
           <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
             <div className="flex items-end justify-between gap-3">
               <div>
@@ -179,15 +174,11 @@ export default function HomePage() {
               ))}
             </div>
           </section>
-
-          {/* 부상 선수 섹션 — News 바로 아래, 같은 col-span-2 안 (오른쪽 사이드 카드와 나란히) */}
-          <InjuredPlayersStrip />
         </FadeIn>
 
-        {/* 사이드 카드 (3열 중 1열) */}
+        {/* 우측 부상 선수 섹션 (3열 중 1열) */}
         <FadeIn className="lg:col-span-1" delayMs={120}>
-          {/* 삼항 연산자로 로그인 상태에 따라 다른 카드 표시 */}
-          {authed ? <DraftSetupCard /> : <SignInCard />}
+          <InjuredPlayersStrip />
         </FadeIn>
       </div>
     </div>


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Removed `SignInCard` and `DraftSetupCard`
- Moved `InjuredPlayersStrip` into the right column (1/3)
- Login entry now comes solely from the Navbar Login button
- 
## Why
<!-- Why did you do it? -->
- Home's Draft Setup card created a confusing entry flow: clicking
  Navbar → Draft would bounce users back to Home when no unsaved draft
  existed.
- Splitting "start a draft" between Home and the Draft page weakened
  the mental model.

## Related Issue
<!-- e.g. #123 -->
#86 