### PR TITLE
AL/NL/Custom league filter + per-position roster constraints

### DIFF
--- a/fe/src/features/draft/utils.ts
+++ b/fe/src/features/draft/utils.ts
@@ -1,16 +1,40 @@
-import type { DraftConfigLocal, DraftPick, DraftTeam } from "../../types/draft";
+import type {
+  DraftConfigLocal,
+  DraftPick,
+  DraftTeam,
+  RosterSlotCounts,
+  RosterSlotPosition,
+} from "../../types/draft";
+
+/**
+ * 기본 14-슬롯 구성:
+ *   C, 1B, 2B, 3B, SS, OF×3, UTIL, SP×2, RP×2, BENCH×3
+ */
+export const DEFAULT_ROSTER_SLOTS: RosterSlotCounts = {
+  C: 1, "1B": 1, "2B": 1, "3B": 1, SS: 1,
+  OF: 3, UTIL: 1,
+  SP: 2, RP: 2,
+  BENCH: 3,
+};
+
+/** 합계 = rosterPlayers 가 되어야 한다는 검증용. */
+export function sumRosterSlots(slots: RosterSlotCounts): number {
+  return Object.values(slots).reduce((sum, n) => sum + n, 0);
+}
 
 export const DEFAULT_CONFIG = {
   myTeamName: "My Team",
   oppTeamNames: [] as string[],
   opponentsCount: 0,
-  leagueType: "standard",
+  leagueType: "AL",
   budget: 260,
-  rosterPlayers: 12,
+  rosterPlayers: sumRosterSlots(DEFAULT_ROSTER_SLOTS),
+  rosterSlots: DEFAULT_ROSTER_SLOTS,
 } satisfies DraftConfigLocal;
 
 // 옵션 A: 픽 추가 시 클라이언트가 즉시 slotIndex/slotPos 결정.
 // 슬롯 인덱스 → 포지션 매핑은 백엔드와 동일한 베이스 템플릿을 그대로 사용.
+// 옛 세션 (rosterSlots 없는 경우) 의 fallback 으로 남겨둠.
 export const SLOT_TEMPLATE_BASE = [
   "SP", "SP", "RP", "SP", "RP",
   "C", "1B", "2B", "3B", "SS",
@@ -18,6 +42,22 @@ export const SLOT_TEMPLATE_BASE = [
   "BENCH", "BENCH", "BENCH", "BENCH", "BENCH",
   "BENCH", "BENCH", "BENCH", "BENCH", "BENCH",
 ] as const;
+
+// rosterSlots 가 있을 때 사용할 동적 슬롯 빌더.
+// 순서: SP, RP, C, 1B, 2B, 3B, SS, OF, UTIL, BENCH
+// (Draft board 가 사용자가 정한 카운트대로 슬롯을 그리도록 한다.)
+const SLOT_ORDER: RosterSlotPosition[] = [
+  "SP", "RP", "C", "1B", "2B", "3B", "SS", "OF", "UTIL", "BENCH",
+];
+
+export function buildSlotTemplateFromCounts(slots: RosterSlotCounts): string[] {
+  const out: string[] = [];
+  for (const pos of SLOT_ORDER) {
+    const n = slots[pos] ?? 0;
+    for (let i = 0; i < n; i += 1) out.push(pos);
+  }
+  return out;
+}
 
 const TEAM_PALETTE = [
   { header: "border-rose-400/30 bg-rose-500/10 text-rose-200", slot: "border-rose-400/20 bg-rose-500/8", text: "text-rose-200" },

--- a/fe/src/features/home/DraftSetupCard.tsx
+++ b/fe/src/features/home/DraftSetupCard.tsx
@@ -2,11 +2,16 @@ import { useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import logo from "../../assets/LOGO.png";
 import { isAuthed } from "../../lib/auth";
+import {
+  DEFAULT_ROSTER_SLOTS,
+  sumRosterSlots,
+} from "../draft/utils";
+import type { RosterSlotCounts, RosterSlotPosition } from "../../types/draft";
 
-type LeagueType = "standard" | "lite" | "custom";
+export type LeagueType = "AL" | "NL" | "custom";
 
 // 모달 안에서 재사용할 때 onSubmit 으로 동작을 override 한다.
-// (생략 시 기본 동작: localStorage 저장 + /draft?setup=1 로 navigate)
+// (생략 시 기본 동작: localStorage 저장 + /draft 로 navigate)
 // embedded=true 면 카드 wrapper(section, border, padding) 없이 폼 내용만 그린다.
 export type DraftSetupConfig = {
   myTeamName: string;
@@ -15,17 +20,12 @@ export type DraftSetupConfig = {
   leagueType: LeagueType;
   budget: number;
   rosterPlayers: number;
+  rosterSlots: RosterSlotCounts;
 };
 type Props = {
   onSubmit?: (config: DraftSetupConfig) => void;
   embedded?: boolean;
 };
-
-const presets = {
-  standard: { label: "Standard", budget: 260, players: 12, opponents: 11, note: "$260 / 12 players / 12 teams" },
-  lite: { label: "Lite", budget: 200, players: 10, opponents: 9, note: "$200 / 10 players / 10 teams" },
-  custom: { label: "Custom", budget: 260, players: 12, opponents: 0, note: "Set your own" },
-} as const;
 
 const INPUT_CLASS =
   "mt-2 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none transition hover:border-white/30 focus:border-white/40 focus-visible:ring-2 focus-visible:ring-white/20 placeholder:text-white/40";
@@ -49,46 +49,54 @@ function parseIntOr0(s: string): number {
   return Number.isNaN(n) ? 0 : n;
 }
 
-// Robust select-all on focus: deferred to next frame so mouse click positioning
-// doesn't deselect. Works for both tab focus and mouse click.
 function selectAllOnFocus(e: React.FocusEvent<HTMLInputElement>) {
   const target = e.currentTarget;
   requestAnimationFrame(() => target.select());
 }
 
 const OPPONENTS_MAX = 12;
-const ROSTER_MIN = 1;
-const ROSTER_MAX = 12;
 const BUDGET_MIN = 1;
+const SLOT_MIN = 0;
+const SLOT_MAX = 10;
+
+const POSITION_ORDER: RosterSlotPosition[] = [
+  "C", "1B", "2B", "3B", "SS", "OF", "UTIL", "SP", "RP", "BENCH",
+];
+
+// 사용자가 슬롯 합계를 정확히 이 값과 맞춰야 Start Draft 가 활성화된다.
+const TARGET_ROSTER_SIZE = sumRosterSlots(DEFAULT_ROSTER_SLOTS);
+
+const POSITION_LABEL: Record<RosterSlotPosition, string> = {
+  C: "C",
+  "1B": "1B",
+  "2B": "2B",
+  "3B": "3B",
+  SS: "SS",
+  OF: "OF",
+  UTIL: "UTIL",
+  SP: "SP",
+  RP: "RP",
+  BENCH: "BENCH",
+};
 
 export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {}) {
   const navigate = useNavigate();
   const authed = isAuthed();
 
   const [myTeam, setMyTeam] = useState<string>("");
-  const [opponentsCountStr, setOpponentsCountStr] = useState<string>("0");
-  const [oppTeamNames, setOppTeamNames] = useState<string[]>([]);
-  const [leagueType, setLeagueType] = useState<LeagueType>("standard");
-  const [customBudgetStr, setCustomBudgetStr] = useState<string>("260");
-  const [customPlayersStr, setCustomPlayersStr] = useState<string>("12");
+  const [opponentsCountStr, setOpponentsCountStr] = useState<string>("11");
+  const [oppTeamNames, setOppTeamNames] = useState<string[]>(
+    Array.from({ length: 11 }, () => "")
+  );
+  const [leagueType, setLeagueType] = useState<LeagueType>("AL");
+  const [budgetStr, setBudgetStr] = useState<string>("260");
+  const [rosterSlots, setRosterSlots] = useState<RosterSlotCounts>(DEFAULT_ROSTER_SLOTS);
 
-  // Derived, clamped numeric values — single source of truth for downstream logic
+  // Derived numbers
   const opponentsCount = clamp(parseIntOr0(opponentsCountStr), 0, OPPONENTS_MAX);
-  const customBudget = Math.max(BUDGET_MIN, parseIntOr0(customBudgetStr));
-  const customPlayers = clamp(parseIntOr0(customPlayersStr), ROSTER_MIN, ROSTER_MAX);
+  const budget = Math.max(BUDGET_MIN, parseIntOr0(budgetStr));
+  const rosterPlayers = useMemo(() => sumRosterSlots(rosterSlots), [rosterSlots]);
 
-  const computed = useMemo(() => {
-    if (leagueType === "custom") {
-      return {
-        budget: customBudget,
-        players: customPlayers,
-        note: `$${customBudget} / ${customPlayers} players`,
-      };
-    }
-    return presets[leagueType];
-  }, [leagueType, customBudget, customPlayers]);
-
-  // Sync oppTeamNames array with a given count (keep existing entries, pad/trim)
   const syncOppTeamNames = (count: number) => {
     setOppTeamNames((prev) => {
       if (count === prev.length) return prev;
@@ -97,29 +105,10 @@ export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {
     });
   };
 
-  // Central update: set input string + sync names synchronously so UI stays in lockstep
   const updateOpponentsCount = (str: string) => {
     setOpponentsCountStr(str);
     const c = clamp(parseIntOr0(str), 0, OPPONENTS_MAX);
     syncOppTeamNames(c);
-  };
-
-  // In Custom mode, Roster Players drives both roster size and opponent count
-  // (matching Standard/Lite pattern where "N players = N teams"). Typing here
-  // immediately creates N opponent name boxes.
-  const updateCustomPlayers = (str: string) => {
-    setCustomPlayersStr(str);
-    const p = clamp(parseIntOr0(str), ROSTER_MIN, ROSTER_MAX);
-    // X players → X opponents (so user sees X name boxes matching their input)
-    updateOpponentsCount(String(p));
-  };
-
-  const applyLeagueType = (type: LeagueType) => {
-    setLeagueType(type);
-    // Custom preserves user's current opponents count; Standard/Lite apply preset
-    if (type !== "custom") {
-      updateOpponentsCount(String(presets[type].opponents));
-    }
   };
 
   const updateOppTeamName = (index: number, value: string) => {
@@ -130,28 +119,39 @@ export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {
     });
   };
 
+  const adjustSlot = (pos: RosterSlotPosition, delta: number) => {
+    setRosterSlots((prev) => ({
+      ...prev,
+      [pos]: clamp((prev[pos] ?? 0) + delta, SLOT_MIN, SLOT_MAX),
+    }));
+  };
+
+  // 슬롯 합계가 정확히 TARGET_ROSTER_SIZE 와 일치해야 시작 가능.
+  const rosterDelta = rosterPlayers - TARGET_ROSTER_SIZE;
+  const canStart = rosterDelta === 0;
+
   const onStartDraft = () => {
+    if (!canStart) return;
     const config: DraftSetupConfig = {
       myTeamName: myTeam.trim() || "My Team",
       opponentsCount,
       oppTeamNames: oppTeamNames.map((name, i) => name.trim() || `Opponent ${i + 1}`),
       leagueType,
-      budget: computed.budget,
-      rosterPlayers: computed.players,
+      budget,
+      rosterPlayers,
+      rosterSlots,
     };
 
-    // 모달 컨텍스트에서는 onSubmit 으로 부모(DraftPage)가 state 를 직접 갱신한다.
     if (onSubmit) {
       onSubmit(config);
       return;
     }
 
-    // 기본 동작: ppadun_unsaved_draft 에 저장하고 /draft 로 이동.
     localStorage.setItem(
       "ppadun_unsaved_draft",
       JSON.stringify({ config, picks: [] })
     );
-    navigate("/draft?setup=1");
+    navigate("/draft");
   };
 
   const body = (
@@ -177,8 +177,40 @@ export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {
         </div>
 
         <div>
+          <div className="text-xs font-extrabold text-white/70">League</div>
+          <div className="mt-2 flex gap-2">
+            <button
+              type="button"
+              className={pill(leagueType === "AL")}
+              onClick={() => setLeagueType("AL")}
+            >
+              <div className="text-sm font-black text-white">AL</div>
+              <div className="mt-1 text-xs text-white/60">American League only</div>
+            </button>
+
+            <button
+              type="button"
+              className={pill(leagueType === "NL")}
+              onClick={() => setLeagueType("NL")}
+            >
+              <div className="text-sm font-black text-white">NL</div>
+              <div className="mt-1 text-xs text-white/60">National League only</div>
+            </button>
+
+            <button
+              type="button"
+              className={pill(leagueType === "custom")}
+              onClick={() => setLeagueType("custom")}
+            >
+              <div className="text-sm font-black text-white">Custom</div>
+              <div className="mt-1 text-xs text-white/60">Both leagues</div>
+            </button>
+          </div>
+        </div>
+
+        <div>
           <label className="text-xs font-extrabold text-white/70">
-            Participants (opponents) <span className="text-white/40">(max 12)</span>
+            Participants (opponents) <span className="text-white/40">(max {OPPONENTS_MAX})</span>
           </label>
 
           <div className="mt-2 flex items-center gap-2">
@@ -212,8 +244,6 @@ export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {
             </button>
           </div>
 
-          <div className="mt-1 text-xs text-white/50">Enter how many opponents you&apos;ll draft with.</div>
-
           {opponentsCount > 0 && (
             <div className="mt-3 space-y-2 rounded-2xl border border-white/10 bg-black/20 p-3">
               <div className="text-xs font-extrabold text-white/70">Opponent names</div>
@@ -234,89 +264,79 @@ export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {
         </div>
 
         <div>
-          <div className="text-xs font-extrabold text-white/70">League type</div>
-          <div className="mt-2 flex gap-2">
-            <button
-              type="button"
-              className={pill(leagueType === "standard")}
-              onClick={() => applyLeagueType("standard")}
-            >
-              <div className="text-sm font-black text-white">Standard</div>
-              <div className="mt-1 text-xs text-white/60">$260 / 12 players / 12 teams</div>
-            </button>
-
-            <button
-              type="button"
-              className={pill(leagueType === "lite")}
-              onClick={() => applyLeagueType("lite")}
-            >
-              <div className="text-sm font-black text-white">Lite</div>
-              <div className="mt-1 text-xs text-white/60">$200 / 10 players / 10 teams</div>
-            </button>
-
-            <button
-              type="button"
-              className={pill(leagueType === "custom")}
-              onClick={() => applyLeagueType("custom")}
-            >
-              <div className="text-sm font-black text-white">Custom</div>
-              <div className="mt-1 text-xs text-white/60">Set your own</div>
-            </button>
-          </div>
+          <label className="text-xs font-extrabold text-white/70">Budget ($)</label>
+          <input
+            type="number"
+            inputMode="numeric"
+            min={BUDGET_MIN}
+            value={budgetStr}
+            onFocus={selectAllOnFocus}
+            onChange={(e) => setBudgetStr(e.target.value)}
+            className={`${INPUT_CLASS} no-spinner`}
+          />
         </div>
 
-        {leagueType === "custom" && (
-          <div className="grid grid-cols-2 gap-3">
-            <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-              <div className="text-xs font-bold text-white/70">Budget ($)</div>
-              <input
-                type="number"
-                inputMode="numeric"
-                min={BUDGET_MIN}
-                value={customBudgetStr}
-                onFocus={selectAllOnFocus}
-                onChange={(e) => setCustomBudgetStr(e.target.value)}
-                className={`${INPUT_CLASS_COMPACT} no-spinner`}
-              />
+        <div className="rounded-2xl border border-white/10 bg-black/20 p-3">
+          <div className="flex items-center justify-between">
+            <div className="text-xs font-extrabold text-white/70">Roster slots by position</div>
+            <div className="text-xs font-black">
+              <span className="text-white/70">Total: </span>
+              <span className={canStart ? "text-emerald-300" : "text-rose-300"}>
+                {rosterPlayers}
+              </span>
+              <span className="text-white/40"> / {TARGET_ROSTER_SIZE}</span>
             </div>
+          </div>
 
-            <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-              <div className="text-xs font-bold text-white/70">
-                Roster players <span className="text-white/40">(max {ROSTER_MAX})</span>
+          <div className="mt-3 grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {POSITION_ORDER.map((pos) => (
+              <div
+                key={pos}
+                className="flex items-center justify-between rounded-xl border border-white/10 bg-black/30 px-3 py-2"
+              >
+                <div className="text-xs font-black text-white/80">{POSITION_LABEL[pos]}</div>
+                <div className="flex items-center gap-1">
+                  <button
+                    type="button"
+                    onClick={() => adjustSlot(pos, -1)}
+                    className="grid h-7 w-7 place-items-center rounded-lg border border-white/10 bg-black/30 text-white/80 hover:bg-white/5"
+                    aria-label={`Decrease ${pos}`}
+                  >
+                    -
+                  </button>
+                  <div className="min-w-6 text-center text-sm font-black text-white">
+                    {rosterSlots[pos]}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => adjustSlot(pos, 1)}
+                    className="grid h-7 w-7 place-items-center rounded-lg border border-white/10 bg-black/30 text-white/80 hover:bg-white/5"
+                    aria-label={`Increase ${pos}`}
+                  >
+                    +
+                  </button>
+                </div>
               </div>
-              <input
-                type="number"
-                inputMode="numeric"
-                min={ROSTER_MIN}
-                max={ROSTER_MAX}
-                value={customPlayersStr}
-                onFocus={selectAllOnFocus}
-                onChange={(e) => updateCustomPlayers(e.target.value)}
-                className={`${INPUT_CLASS_COMPACT} no-spinner`}
-              />
-            </div>
-          </div>
-        )}
-
-        <div className="grid grid-cols-2 gap-3">
-          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-            <div className="text-xs font-bold text-white/70">Budget ($)</div>
-            <div className="mt-2 text-2xl font-black text-white">{computed.budget}</div>
-          </div>
-
-          <div className="rounded-2xl border border-white/10 bg-black/30 p-4">
-            <div className="text-xs font-bold text-white/70">Roster players</div>
-            <div className="mt-2 text-2xl font-black text-white">{computed.players}</div>
+            ))}
           </div>
         </div>
 
         <button
           type="button"
           onClick={onStartDraft}
-          className="mt-1 w-full rounded-2xl bg-white px-4 py-3 text-sm font-black text-black transition hover:translate-y-[-1px] hover:bg-white/90 active:translate-y-0"
+          disabled={!canStart}
+          className="mt-1 w-full rounded-2xl bg-white px-4 py-3 text-sm font-black text-black transition hover:-translate-y-px hover:bg-white/90 active:translate-y-0 disabled:cursor-not-allowed disabled:bg-white/30 disabled:hover:translate-y-0"
         >
           Start Draft
         </button>
+
+        {!canStart && (
+          <div className="text-center text-xs text-rose-300">
+            {rosterDelta < 0
+              ? `Add ${-rosterDelta} more roster slot${-rosterDelta === 1 ? "" : "s"} to reach ${TARGET_ROSTER_SIZE} players.`
+              : `Remove ${rosterDelta} roster slot${rosterDelta === 1 ? "" : "s"} to fit ${TARGET_ROSTER_SIZE} players.`}
+          </div>
+        )}
 
         {!authed && (
           <div className="text-center text-xs text-white/50">

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -36,8 +36,8 @@ import type {
 type DraftPosition = DraftPlayer["positions"][number];
 
 import {
-  SLOT_TEMPLATE_BASE,
-  buildSlotTemplate,
+  DEFAULT_ROSTER_SLOTS,
+  buildSlotTemplateFromCounts,
   calculateCurrentRound,
   calculateRemainingBudget,
   clampRosterSize,
@@ -46,6 +46,7 @@ import {
   formatAvg,
   getPlayerDraftStatus,
   mlbTeamBadgeClass,
+  sumRosterSlots,
 } from "../features/draft/utils";
 import { formatPpa, ppaValueClass } from "../utils/playerValue";
 
@@ -171,12 +172,13 @@ type SessionsListResponse = {
 const UNSAVED_DRAFT_KEY = "ppadun_unsaved_draft";
 
 const DEFAULT_DRAFT_CONFIG: DraftConfigServer = {
-  leagueType: "standard",
+  leagueType: "AL",
   budget: 260,
-  rosterPlayers: 12,
+  rosterPlayers: sumRosterSlots(DEFAULT_ROSTER_SLOTS),
   myTeamName: "My Team",
   opponentsCount: 11,
   oppTeamNames: Array.from({ length: 11 }, (_, i) => `Opponent ${i + 1}`),
+  rosterSlots: DEFAULT_ROSTER_SLOTS,
 };
 
 // 미저장 모드의 localStorage 페이로드 — DraftSetupCard 가 쓰고 DraftPage 가 읽음
@@ -298,11 +300,19 @@ export default function DraftPage() {
   const [saving, setSaving] = useState(false);
   const [importModalOpen, setImportModalOpen] = useState(false);
 
-  const rosterSlots = useMemo(
+  const rosterSize = useMemo(
     () => clampRosterSize(config?.rosterPlayers),
     [config?.rosterPlayers]
   );
-  const slotTemplate = useMemo(() => buildSlotTemplate(rosterSlots), [rosterSlots]);
+  // 옛 세션엔 rosterSlots 가 없을 수 있으므로 기본값 fallback.
+  const rosterSlotCounts = useMemo(
+    () => config?.rosterSlots ?? DEFAULT_ROSTER_SLOTS,
+    [config?.rosterSlots]
+  );
+  const slotTemplate = useMemo(
+    () => buildSlotTemplateFromCounts(rosterSlotCounts),
+    [rosterSlotCounts]
+  );
 
   // 공개 선수 목록 + 인증 값 목록을 playerId 로 머지한 최종 UI 목록
   const allPlayers = useMemo<DraftPlayer[]>(
@@ -390,8 +400,8 @@ export default function DraftPage() {
 
   const currentRound = useMemo(() => {
     if (teams.length === 0) return 1;
-    return calculateCurrentRound(teams.length, rosterSlots, picks);
-  }, [teams.length, rosterSlots, picks]);
+    return calculateCurrentRound(teams.length, rosterSize, picks);
+  }, [teams.length, rosterSize, picks]);
 
   const selectedA = players.find((player) => player.id === compareAId) ?? null;
   const selectedB = players.find((player) => player.id === compareBId) ?? null;
@@ -422,6 +432,7 @@ export default function DraftPage() {
       myTeamName: next.myTeamName,
       opponentsCount: next.opponentsCount,
       oppTeamNames: next.oppTeamNames,
+      rosterSlots: next.rosterSlots,
     };
     try {
       localStorage.setItem(
@@ -531,7 +542,12 @@ export default function DraftPage() {
     }
   }, [isLoadedMode, bootstrapped, config, hasDraftConfig, picks]);
 
-  // 공개 선수 목록 — 한 번만 호출. 검색/필터/정렬/페이지네이션은 아래 useMemo 에서 처리.
+  // 공개 선수 목록 — leagueType 이 바뀌면 다시 불러온다.
+  // AL/NL 은 ?league= 쿼리로 백엔드 필터링, 그 외(custom 등)는 전체.
+  const leagueQuery =
+    config?.leagueType === "AL" || config?.leagueType === "NL"
+      ? config.leagueType
+      : null;
   useEffect(() => {
     const controller = new AbortController();
     queueMicrotask(() => {
@@ -539,7 +555,11 @@ export default function DraftPage() {
       setError(null);
     });
 
-    apiGet<DraftPlayersResponse>("/api/draft/players", undefined, controller.signal)
+    const path = leagueQuery
+      ? `/api/draft/players?league=${leagueQuery}`
+      : "/api/draft/players";
+
+    apiGet<DraftPlayersResponse>(path, undefined, controller.signal)
       .then((data) => {
         if (controller.signal.aborted) return;
         setPublicPlayers(data.items ?? []);
@@ -557,7 +577,7 @@ export default function DraftPage() {
       });
 
     return () => controller.abort();
-  }, []);
+  }, [leagueQuery]);
 
   // 인증된 사용자에게만 PPA 값 + 추천 bid 를 불러와 playerId 로 공개 목록과 머지한다.
   // 로그아웃 시 값을 즉시 지워서 UI 에 남지 않도록 함.
@@ -666,13 +686,13 @@ export default function DraftPage() {
     const occupied = new Set(
       filtered.filter((p) => p.draftedByTeamId === draftedByTeamId).map((p) => p.slotIndex)
     );
-    const slotIndex = findAvailableSlotIndex(rosterSlots, occupied);
+    const slotIndex = findAvailableSlotIndex(rosterSize, occupied);
     if (slotIndex === -1) {
       alert("No roster slot available");
       return false;
     }
 
-    const slotPos = SLOT_TEMPLATE_BASE[slotIndex] as DraftPosition;
+    const slotPos = (slotTemplate[slotIndex] ?? "BENCH") as DraftPosition;
     const next: DraftPick = { playerId, draftedByTeamId, slotIndex, slotPos, bid, type };
     setPicks([...filtered, next]);
     return true;
@@ -823,7 +843,7 @@ export default function DraftPage() {
             </h1>
             {hasDraftConfig ? (
               <p className="mt-2 text-sm text-white/60">
-                {String(config.leagueType ?? "standard").toUpperCase()} - ${config.budget} Budget - {rosterSlots} Players
+                {String(config.leagueType ?? "AL").toUpperCase()} - ${config.budget} Budget - {rosterSize} Players
               </p>
             ) : (
               <p className="mt-2 text-sm text-white/60">
@@ -885,7 +905,7 @@ export default function DraftPage() {
               picks={picks}
               playersById={playersById}
               currentRound={currentRound}
-              totalRounds={rosterSlots}
+              totalRounds={rosterSize}
               authed={authed}
               onRemovePick={handleRemovePick}
             />

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -76,15 +76,17 @@ export type DraftConfigLocal = {
   myTeamName?: string;
   oppTeamNames?: string[];       // 상대 팀 이름들
   opponentsCount?: number;       // 상대 수
-  leagueType?: string;           // "standard" | "lite" | "custom"
+  leagueType?: string;           // "AL" | "NL" | "custom" (옛 세션은 "standard"|"lite" 가능 — fallback 처리)
   budget?: number;               // 예산 ($)
   rosterPlayers?: number;        // 로스터 인원
+  rosterSlots?: RosterSlotCounts; // 포지션별 슬롯 수
   createdAt?: string;            // 설정 생성 시간
 };
 
 /**
  * DraftConfigServer: 백엔드 세션 응답에 들어 있는 config 형태
  * - DraftConfigLocal 과 달리 모든 필드가 필수 (서버가 정규화한 값)
+ * - rosterSlots 는 옛 세션엔 없을 수 있어 선택적
  */
 export type DraftConfigServer = {
   leagueType: string;
@@ -93,7 +95,16 @@ export type DraftConfigServer = {
   myTeamName: string;
   opponentsCount: number;
   oppTeamNames: string[];
+  rosterSlots?: RosterSlotCounts;
 };
+
+/**
+ * RosterSlotCounts: Draft Setup 모달에서 사용자가 정한 포지션별 슬롯 수.
+ * 합계가 rosterPlayers 와 일치해야 Start Draft 가 활성화된다.
+ */
+export type RosterSlotPosition =
+  | "C" | "1B" | "2B" | "3B" | "SS" | "OF" | "UTIL" | "SP" | "RP" | "BENCH";
+export type RosterSlotCounts = Record<RosterSlotPosition, number>;
 
 /**
  * SessionSummary: GET /api/draft/sessions 의 각 항목 (Import 모달용)


### PR DESCRIPTION


## What
<!-- What did you do? -->
- League pills: **AL / NL / Custom** (Custom = both leagues, no filter)
- AL/NL → `?league=AL|NL` appended to `/api/draft/players`
- Per-position +/- controls in the setup modal
- Start Draft disabled unless slot total equals 14, with a clear delta
  message ("Add N more" / "Remove N")
- New `RosterSlotCounts` type flows through `DraftConfigServer`
- `DraftRoomBoard` now builds its slot template from the user's counts
- Default config switched from `standard`/12 to `AL`/14

## Why
<!-- Why did you do it? -->
Replace the Standard/Lite preset with an explicit AL/NL/Custom selector
that filters the player pool, and let users configure roster slots per
position.


## Related Issue
<!-- e.g. #123 -->
#88 