### PR TITLE
Improve Google Sign-In hook stability

### DIFF
--- a/fe/.env.development
+++ b/fe/.env.development
@@ -7,3 +7,6 @@ VITE_API_PROXY_TARGET=http://127.0.0.1:8000
 # App runtime defaults
 VITE_DRAFT_ROOM_ID=default
 VITE_MY_TEAM_ID=team-me
+
+# Google OAuth Client ID (Google Cloud Console에서 발급)
+VITE_GOOGLE_CLIENT_ID=96806984873-n9in5glb21d6lni6acqnkdrcmk9b6b2c.apps.googleusercontent.com

--- a/fe/.env.example
+++ b/fe/.env.example
@@ -9,3 +9,6 @@ VITE_API_PROXY_TARGET=http://127.0.0.1:8000
 # App runtime defaults
 VITE_DRAFT_ROOM_ID=default
 VITE_MY_TEAM_ID=team-me
+
+# Google OAuth Client ID — Google Cloud Console에서 발급받은 값
+VITE_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com

--- a/fe/src/features/auth/LoginPromptModal.tsx
+++ b/fe/src/features/auth/LoginPromptModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import Modal from "../../components/ui/Modal";
 import { useGoogleSignIn } from "../../lib/googleAuth";
 
@@ -10,10 +11,16 @@ type Props = {
 // 비로그인 유저가 보호된 액션(예: Start Your Draft)을 시도했을 때 띄우는 모달.
 // 구글 로그인 성공 시 onAuthSuccess 콜백 실행 후 모달을 닫는다.
 export default function LoginPromptModal({ open, onClose, onAuthSuccess }: Props) {
-  const buttonRef = useGoogleSignIn(() => {
-    onAuthSuccess?.();
-    onClose();
-  });
+  const [authError, setAuthError] = useState<string | null>(null);
+
+  const buttonRef = useGoogleSignIn(
+    () => {
+      setAuthError(null);
+      onAuthSuccess?.();
+      onClose();
+    },
+    (msg) => setAuthError(msg),
+  );
 
   return (
     <Modal open={open} title="Sign in to continue" onClose={onClose}>
@@ -22,6 +29,11 @@ export default function LoginPromptModal({ open, onClose, onAuthSuccess }: Props
           Sign in with Google to start and save your draft.
         </p>
         <div ref={buttonRef} className="w-full max-w-xs" />
+        {authError && (
+          <div className="w-full max-w-xs rounded-2xl border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-200">
+            {authError}
+          </div>
+        )}
       </div>
     </Modal>
   );

--- a/fe/src/features/home/SignInCard.tsx
+++ b/fe/src/features/home/SignInCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import logo from "../../assets/LOGO.png";
 import { useGoogleSignIn } from "../../lib/googleAuth";
@@ -5,11 +6,16 @@ import { useGoogleSignIn } from "../../lib/googleAuth";
 export default function SignInCard() {
   const navigate = useNavigate();
   const location = useLocation();
+  const [authError, setAuthError] = useState<string | null>(null);
 
-  const buttonRef = useGoogleSignIn(() => {
-    const redirect = location.pathname + location.search;
-    navigate(redirect === "/login" ? "/" : redirect, { replace: true });
-  });
+  const buttonRef = useGoogleSignIn(
+    () => {
+      setAuthError(null);
+      const redirect = location.pathname + location.search;
+      navigate(redirect === "/login" ? "/" : redirect, { replace: true });
+    },
+    (msg) => setAuthError(msg),
+  );
 
   return (
     <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
@@ -26,6 +32,12 @@ export default function SignInCard() {
         </div>
 
         <div ref={buttonRef} className="mt-6 w-full opacity-85 transition hover:opacity-100" />
+
+        {authError && (
+          <div className="mt-3 w-full rounded-2xl border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-200">
+            {authError}
+          </div>
+        )}
 
         <div className="mt-8 w-full border-t border-white/10 pt-6 text-left">
           <div className="text-xs font-black text-white/70">What you get with PPA-DUN:</div>

--- a/fe/src/lib/googleAuth.ts
+++ b/fe/src/lib/googleAuth.ts
@@ -6,10 +6,21 @@ import { useCallback, useEffect, useRef } from "react";
 import { apiPost } from "./api";
 import { login } from "./auth";
 
-// Google Cloud Console에서 발급받은 OAuth 클라이언트 ID
-// - 이 ID를 통해 Google에 "이 앱이다"라고 알림
-export const GOOGLE_CLIENT_ID =
-  "96806984873-n9in5glb21d6lni6acqnkdrcmk9b6b2c.apps.googleusercontent.com";
+// Google OAuth 클라이언트 ID — 환경변수로 주입 (환경별로 다른 ID 가능)
+// .env.development / .env.production 에 VITE_GOOGLE_CLIENT_ID 설정 필요
+const RAW_GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID as
+  | string
+  | undefined;
+
+if (!RAW_GOOGLE_CLIENT_ID) {
+  // 빌드/런타임 단계에서 즉시 실패시켜야 잘못된 환경 설정을 빨리 발견
+  throw new Error(
+    "VITE_GOOGLE_CLIENT_ID is not set. Add it to your .env file."
+  );
+}
+
+// 위에서 throw 했으므로 여기서부터는 반드시 string (TS narrowing이 안 되어 별도 const)
+export const GOOGLE_CLIENT_ID: string = RAW_GOOGLE_CLIENT_ID;
 
 // Google이 로그인 성공 시 반환하는 객체 타입
 export type GoogleCredentialResponse = {
@@ -26,6 +37,19 @@ type AuthResponse = {
     name: string;
   };
 };
+
+// Google Identity Services 버튼 설정 — 리터럴 유니온으로 오타 방지
+type ButtonConfig = {
+  type?: "standard" | "icon";
+  theme?: "outline" | "filled_blue" | "filled_black";
+  size?: "small" | "medium" | "large";
+  text?: "signin_with" | "signup_with" | "continue_with" | "signin";
+  shape?: "rectangular" | "pill" | "circle" | "square";
+  logo_alignment?: "left" | "center";
+  width?: number;  // Google IS는 픽셀 숫자만 받음 ("100%" 같은 문자열은 무시됨)
+  locale?: string;
+};
+
 // Google의 전역 객체 타입 (window.google.accounts.id)
 // - Google Identity Services 스크립트가 index.html에서 로드됨
 type GoogleAccountsId = {
@@ -33,41 +57,60 @@ type GoogleAccountsId = {
     client_id: string;
     callback: (r: GoogleCredentialResponse) => void;
   }) => void;
-  renderButton: (el: HTMLElement, config: Record<string, string>) => void;
+  renderButton: (el: HTMLElement, config: ButtonConfig) => void;
+  cancel: () => void;
 };
 
+// window.google 을 전역 타입으로 선언 → 매번 `as unknown as` 단언 불필요
+declare global {
+  interface Window {
+    google?: { accounts?: { id?: GoogleAccountsId } };
+  }
+}
+
 // Google 로그인 버튼의 기본 스타일 설정
-const BUTTON_CONFIG = {
+// - width 는 부모 div 의 CSS 로 제어 (Google IS는 "100%" 문자열을 무시함)
+const BUTTON_CONFIG: ButtonConfig = {
   theme: "outline",       // 아웃라인 스타일
   size: "large",          // 크기
-  width: "100%",          // 전체 너비
   text: "signin_with",    // 버튼 텍스트: "Sign in with Google"
   shape: "pill",          // 둥근 알약 모양
   locale: "en",           // 영어 표시
 };
 
+// Google IS 스크립트 로딩 폴링 간격(ms) / 최대 대기 시간(ms)
+const SCRIPT_POLL_INTERVAL_MS = 100;
+const SCRIPT_POLL_TIMEOUT_MS = 10_000;
+
 /**
  * useGoogleSignIn: Google 로그인 기능을 간편하게 붙여주는 커스텀 훅
  *
  * 사용 방법:
- *   const buttonRef = useGoogleSignIn(() => navigate("/"));
+ *   const buttonRef = useGoogleSignIn(
+ *     () => navigate("/"),
+ *     (msg) => setError(msg),  // (선택) 에러 메시지 표시
+ *   );
  *   return <div ref={buttonRef} />;  // ← 여기에 Google 버튼이 렌더링됨
  *
  * 동작 흐름:
  * 1. ref를 DOM div에 연결
- * 2. Google 라이브러리가 그 div 안에 로그인 버튼을 그림
- * 3. 유저가 버튼 클릭 → Google이 ID 토큰 발급
- * 4. 토큰을 백엔드에 전송 → 검증 + DB 저장
- * 5. localStorage에 토큰 저장
- * 6. onSuccess 콜백 실행 (보통 페이지 이동)
+ * 2. Google IS 스크립트가 로드될 때까지 폴링 (최대 10초)
+ * 3. Google 라이브러리가 그 div 안에 로그인 버튼을 그림
+ * 4. 유저가 버튼 클릭 → Google이 ID 토큰 발급
+ * 5. 토큰을 백엔드에 전송 → 검증 + DB 저장
+ * 6. 응답 검증 후 localStorage에 토큰 저장
+ * 7. onSuccess 콜백 실행 (보통 페이지 이동)
+ * 8. 실패 시 onError 콜백 호출 (UI 알림 가능)
  */
-export function useGoogleSignIn(onSuccess: () => void) {
+export function useGoogleSignIn(
+  onSuccess: () => void,
+  onError?: (message: string) => void,
+) {
   // useRef<HTMLDivElement>: 타입이 HTMLDivElement인 ref 생성
   // - 초기값 null, 나중에 실제 DOM div가 연결됨
   const buttonRef = useRef<HTMLDivElement>(null);
 
-  // useCallback: onSuccess가 바뀔 때만 함수를 새로 만듦
-  // - useEffect의 의존성 배열에서 불필요한 재실행 방지
+  // useCallback: onSuccess / onError 가 바뀔 때만 함수를 새로 만듦
   const handleCredential = useCallback(
     (response: GoogleCredentialResponse) => {
       // 백엔드로 Google 토큰 전송 → 검증 + DB 저장 → 응답 받기
@@ -75,35 +118,74 @@ export function useGoogleSignIn(onSuccess: () => void) {
         credential: response.credential,
       })
         .then((data) => {
+          // 응답 형태 검증 — undefined가 localStorage에 저장되는 사고 방지
+          // (이전에 백엔드 에러 응답이 들어왔을 때 "undefined" 토큰이 저장되던 버그)
+          if (!data?.access_token || typeof data.access_token !== "string") {
+            throw new Error("Invalid auth response: missing access_token");
+          }
           login(data.access_token);
           onSuccess();
         })
-        .catch((err) => console.error("Google login failed:", err));
+        .catch((err: unknown) => {
+          const message =
+            err instanceof Error ? err.message : "Google login failed";
+          console.error("Google login failed:", err);
+          onError?.(message);
+        });
     },
-    [onSuccess]  // 의존성: onSuccess가 바뀌면 함수 재생성
+    [onSuccess, onError],
   );
 
-  // useEffect: 컴포넌트가 렌더링된 후 실행
-  // - 두 번째 인자 [handleCredential]: 이 값이 바뀔 때만 재실행
+  // useEffect: 컴포넌트 마운트 시 실행 + handleCredential 변경 시 재실행
   useEffect(() => {
-    // window.google 객체에서 Google Identity Services API 가져오기
-    // - as unknown as: 타입 단언 (TS에게 타입 강제)
-    const google = (window as unknown as {
-      google?: { accounts?: { id?: GoogleAccountsId } };
-    }).google;
+    let cancelled = false;
+    let pollTimer: number | undefined;
+    const startedAt = Date.now();
+    // 클로저로 ref 의 현재 값을 캡처 → cleanup 시점에 ref.current 가 바뀌어도 안전
+    const containerOnMount = buttonRef.current;
 
-    // Google API가 로드되지 않았거나 ref가 아직 DOM에 연결되지 않았으면 종료
-    if (!google?.accounts?.id || !buttonRef.current) return;
+    // Google Identity Services 스크립트가 로드될 때까지 폴링
+    // - 마운트 시점에 스크립트가 아직 안 왔어도 결국 버튼이 그려지도록 보장
+    const tryInit = () => {
+      if (cancelled) return;
 
-    // Google Sign-In 초기화
-    google.accounts.id.initialize({
-      client_id: GOOGLE_CLIENT_ID,
-      callback: handleCredential,  // 로그인 성공 시 호출될 함수
-    });
+      const google = window.google?.accounts?.id;
+      const container = buttonRef.current;
 
-    // 실제 로그인 버튼을 DOM에 렌더링
-    google.accounts.id.renderButton(buttonRef.current, BUTTON_CONFIG);
-  }, [handleCredential]);
+      if (!google || !container) {
+        // 10초가 지나도 안 오면 포기 (네트워크 차단 / 광고 차단기 등)
+        if (Date.now() - startedAt > SCRIPT_POLL_TIMEOUT_MS) {
+          const message =
+            "Google Sign-In script failed to load. Check your network or ad blocker.";
+          console.error(message);
+          onError?.(message);
+          return;
+        }
+        pollTimer = window.setTimeout(tryInit, SCRIPT_POLL_INTERVAL_MS);
+        return;
+      }
+
+      google.initialize({
+        client_id: GOOGLE_CLIENT_ID,
+        callback: handleCredential,
+      });
+
+      // 컨테이너를 비우고 다시 그림 → effect 재실행 시 버튼이 중복 쌓이는 것 방지
+      container.innerHTML = "";
+      google.renderButton(container, BUTTON_CONFIG);
+    };
+
+    tryInit();
+
+    // cleanup: 언마운트 또는 effect 재실행 직전에 호출
+    // - 폴링 중단, 진행 중인 OAuth 흐름 취소, 버튼 DOM 정리
+    return () => {
+      cancelled = true;
+      if (pollTimer !== undefined) window.clearTimeout(pollTimer);
+      window.google?.accounts?.id?.cancel();
+      if (containerOnMount) containerOnMount.innerHTML = "";
+    };
+  }, [handleCredential, onError]);
 
   // ref를 반환해서 컴포넌트가 자기 div에 붙일 수 있게 함
   return buttonRef;

--- a/fe/src/pages/LoginPage.tsx
+++ b/fe/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 // useNavigate: 페이지 이동 함수
 // useSearchParams: URL의 쿼리 파라미터(?foo=bar)를 읽는 훅
+import { useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 // Google OAuth 공통 훅
 import { useGoogleSignIn } from "../lib/googleAuth";
@@ -14,8 +15,10 @@ export default function LoginPage() {
   // useSearchParams: [현재 파라미터, 파라미터 변경 함수] 반환
   const [params] = useSearchParams();
 
-  // 에러 파라미터 (예: /login?error=unauthorized)
-  const error = params.get("error");
+  // URL 에러 파라미터 (예: /login?error=unauthorized)
+  const urlError = params.get("error");
+  // 런타임 인증 에러 (Google 로그인 실패 시)
+  const [authError, setAuthError] = useState<string | null>(null);
 
   // redirect 파라미터 읽고 디코딩 (없으면 기본값 "/")
   // decodeURIComponent: encodeURIComponent의 반대 (복원)
@@ -24,11 +27,17 @@ export default function LoginPage() {
     : "/";
 
   // useGoogleSignIn: Google 로그인 버튼을 렌더링하고 인증 흐름 처리
-  // - 콜백은 로그인 성공 시 실행됨
-  // - replace: true → 히스토리 교체 (뒤로가기로 로그인 페이지 복귀 방지)
-  const buttonRef = useGoogleSignIn(() => {
-    navigate(redirect, { replace: true });
-  });
+  // - onSuccess: 로그인 성공 시 실행 (replace: true → 뒤로가기로 로그인 페이지 복귀 방지)
+  // - onError: 실패 시 에러 메시지 받아 UI 표시
+  const buttonRef = useGoogleSignIn(
+    () => {
+      setAuthError(null);
+      navigate(redirect, { replace: true });
+    },
+    (msg) => setAuthError(msg),
+  );
+
+  const error = authError ?? urlError;
 
   return (
     <div className="mx-auto max-w-xl">


### PR DESCRIPTION


## What
<!-- What did you do? -->
- Validate the `/api/auth/google/verify` response before persisting the JWT
- Add `useEffect` cleanup + polling for the Google Identity Services script
- Surface auth errors via an `onError` callback in `LoginPage`, `SignInCard`, `LoginPromptModal`
- Move `GOOGLE_CLIENT_ID` to `VITE_GOOGLE_CLIENT_ID` env var
- Tighten types (`ButtonConfig` literal union, global `Window` declaration); drop invalid `width: "100%"`
- - 
## Why
<!-- Why did you do it? -->
The hook had three latent bugs:
1. If the backend returned an error payload, `data.access_token` was `undefined` and got
   stored in localStorage as the literal string `"undefined"` — silently breaking every
   subsequent authenticated request with no user-visible feedback.
2. No `useEffect` cleanup meant duplicate Google buttons could stack inside the same container
   on re-renders.
3. If the Google IS script loaded after the component mounted, the effect exited early and
   the button was never rendered.

## Related Issue
<!-- e.g. #123 -->
#92 