### PR TITLE
feat: add player note popover in draft room

### DIFF
--- a/fe/src/features/draft/components/PlayerNotePopover.tsx
+++ b/fe/src/features/draft/components/PlayerNotePopover.tsx
@@ -1,0 +1,107 @@
+// 선수 메모 작성 팝오버. 인라인이라고 부르지만 실제로는 fixed-position 모달 형태.
+// DraftPage 의 player row 에서 메모 아이콘 클릭 시 열림. Save 시 부모에 note 문자열을 콜백으로 전달.
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  open: boolean;
+  playerName: string;
+  initialNote: string;
+  saving?: boolean;
+  onSave: (note: string) => void;
+  onClose: () => void;
+};
+
+const NOTE_MAX_LENGTH = 1000;
+
+export default function PlayerNotePopover({
+  open,
+  playerName,
+  initialNote,
+  saving = false,
+  onSave,
+  onClose,
+}: Props) {
+  const [draft, setDraft] = useState(initialNote);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  // open 될 때마다 입력값을 서버 값으로 재동기화 — 같은 컴포넌트가 다른 선수에 재사용되는 경우 대비
+  useEffect(() => {
+    if (open) queueMicrotask(() => setDraft(initialNote));
+  }, [open, initialNote]);
+
+  // 열리는 즉시 textarea 에 포커스 — 사용자가 클릭 후 바로 타이핑할 수 있게
+  useEffect(() => {
+    if (open) textareaRef.current?.focus();
+  }, [open]);
+
+  if (!open) return null;
+
+  const dirty = draft !== initialNote;
+
+  const handleSave = () => {
+    if (saving) return;
+    onSave(draft);
+  };
+
+  return (
+    <div className="fixed inset-0 z-[90] grid place-items-center p-4">
+      <button
+        type="button"
+        aria-label="Close note dialog"
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative w-full max-w-md rounded-3xl border border-white/15 bg-[#0c1220] p-6 shadow-2xl">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="text-xs font-extrabold uppercase text-amber-300/80">Player Note</div>
+            <div className="mt-1 text-lg font-black text-white">{playerName}</div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="grid h-8 w-8 place-items-center rounded-full border border-white/15 bg-black/25 text-sm font-black text-white/80 hover:bg-white/10"
+          >
+            X
+          </button>
+        </div>
+
+        <textarea
+          ref={textareaRef}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value.slice(0, NOTE_MAX_LENGTH))}
+          placeholder="e.g. Watch his wrist injury. $40 max bid."
+          rows={6}
+          className="mt-4 w-full resize-none rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm text-white outline-none placeholder:text-white/40 focus:border-white/25"
+        />
+
+        <div className="mt-1 flex items-center justify-between text-[11px] text-white/45">
+          <span>{draft.length === 0 ? "Save empty to delete this note" : "Save to update"}</span>
+          <span>
+            {draft.length}/{NOTE_MAX_LENGTH}
+          </span>
+        </div>
+
+        <div className="mt-5 flex gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="flex-1 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-black text-white/80 transition hover:bg-white/10 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving || !dirty}
+            className="flex-1 rounded-2xl bg-amber-500 px-4 py-3 text-sm font-black text-black transition hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -30,6 +30,7 @@ import type {
   DraftPositionFilter,
   DraftSort,
   DraftTeam,
+  PlayerNote,
   SessionDetail,
   SessionSummary,
 } from "../types/draft";
@@ -55,6 +56,7 @@ import DraftRoomBoard from "../features/draft/components/DraftRoomBoard";
 import AddBidModal from "../features/draft/components/AddBidModal";
 import TakenBidModal from "../features/draft/components/TakenBidModal";
 import PlayerComparisonModal from "../features/draft/components/PlayerComparisonModal";
+import PlayerNotePopover from "../features/draft/components/PlayerNotePopover";
 import PlayerInfoModal from "../features/players/components/PlayerInfoModal";
 import Pagination from "../features/players/components/Pagination";
 import Modal from "../components/ui/Modal";
@@ -319,6 +321,11 @@ export default function DraftPage() {
   const [addTarget, setAddTarget] = useState<DraftPlayer | null>(null);
   const [takenTarget, setTakenTarget] = useState<DraftPlayer | null>(null);
 
+  // 메모 — playerId → note. 로드 모드에서만 fetch/저장 동작 (세션 ID 필요).
+  const [notes, setNotes] = useState<Record<string, string>>({});
+  const [noteTarget, setNoteTarget] = useState<DraftPlayer | null>(null);
+  const [noteSaving, setNoteSaving] = useState(false);
+
   // Save / Import 모달
   const [saveModalOpen, setSaveModalOpen] = useState(false);
   const [saveNameInput, setSaveNameInput] = useState("");
@@ -448,6 +455,41 @@ export default function DraftPage() {
     setTakenTarget(null);
   };
 
+  // 메모 팝오버 — 로드된 세션에서만 사용 가능 (미저장 모드는 버튼 자체가 비활성화됨).
+  const openNoteModal = (player: DraftPlayer) => {
+    setNoteTarget(player);
+  };
+
+  const closeNoteModal = () => {
+    if (noteSaving) return;
+    setNoteTarget(null);
+  };
+
+  const handleNoteSave = (note: string) => {
+    if (!noteTarget || sessionId === null) return;
+    const playerId = noteTarget.id;
+    const trimmed = note.trim();
+    setNoteSaving(true);
+    apiPutAuth<{ status: string }, { note: string }>(
+      `/api/draft/sessions/${sessionId}/notes/${encodeURIComponent(playerId)}`,
+      { note: trimmed }
+    )
+      .then(() => {
+        setNotes((prev) => {
+          const next = { ...prev };
+          if (trimmed) next[playerId] = trimmed;
+          else delete next[playerId];
+          return next;
+        });
+        setNoteTarget(null);
+      })
+      .catch((err: unknown) => {
+        console.error(err);
+        pushToast("Failed to save note", "error");
+      })
+      .finally(() => setNoteSaving(false));
+  };
+
   // Start Your Draft 모달에서 입력한 config 로 page state 를 갱신.
   // localStorage 도 함께 저장해 새로고침해도 resume 되도록 한다.
   const handleSetupSubmit = (next: DraftSetupConfig) => {
@@ -554,6 +596,32 @@ export default function DraftPage() {
       setBootstrapped(true);
     });
   }, [isLoadedMode, navigate, sessionId]);
+
+  // 로드 모드에서만 메모를 서버에서 가져온다. 미저장 모드는 세션 ID가 없어 메모를 못 저장하므로 fetch도 안 함.
+  useEffect(() => {
+    if (!isLoadedMode || sessionId === null) {
+      queueMicrotask(() => setNotes({}));
+      return;
+    }
+    const controller = new AbortController();
+    apiGetAuth<{ items: PlayerNote[] }>(
+      `/api/draft/sessions/${sessionId}/notes`,
+      undefined,
+      controller.signal
+    )
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        const map: Record<string, string> = {};
+        for (const it of data.items ?? []) map[it.playerId] = it.note;
+        setNotes(map);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.error(err);
+        setNotes({});
+      });
+    return () => controller.abort();
+  }, [isLoadedMode, sessionId]);
 
   // 미저장 모드에서 picks 가 바뀔 때마다 localStorage 에도 sync — 새로고침 보호.
   useEffect(() => {
@@ -1267,13 +1335,45 @@ export default function DraftPage() {
                   >
                     <div className="text-white/45">{(page - 1) * PAGE_SIZE + idx + 1}</div>
 
-                    <div>
+                    <div className="flex items-center gap-1">
                       <button
                         type="button"
                         onClick={() => openPlayerInfo(player.id, player.playerType)}
                         className="rounded-md border border-transparent px-2 py-1 -mx-2 -my-1 font-semibold text-white transition hover:border-white/35 hover:bg-white/5 hover:text-amber-200 focus-visible:border-white/45 focus-visible:bg-white/10 focus-visible:outline-none"
                       >
                         {player.name}
+                      </button>
+                      <button
+                        type="button"
+                        disabled={!authed || !isLoadedMode}
+                        onClick={() => openNoteModal(player)}
+                        aria-label={notes[player.id] ? "Edit note" : "Add note"}
+                        title={
+                          !authed
+                            ? "Sign in required"
+                            : !isLoadedMode
+                            ? "Save your draft first to add notes"
+                            : notes[player.id]
+                            ? "Edit note"
+                            : "Add note"
+                        }
+                        className={[
+                          "grid h-7 w-7 place-items-center rounded-md border transition",
+                          notes[player.id]
+                            ? "border-amber-400/50 bg-amber-500/15 text-amber-300 hover:bg-amber-500/25"
+                            : "border-white/10 bg-white/5 text-white/55 hover:bg-white/10 hover:text-white/80",
+                          (!authed || !isLoadedMode) && "cursor-not-allowed opacity-40 hover:bg-white/5",
+                        ]
+                          .filter(Boolean)
+                          .join(" ")}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                          <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+                          <path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2Z" />
+                          <path d="M9 9h1" />
+                          <path d="M9 13h6" />
+                          <path d="M9 17h6" />
+                        </svg>
                       </button>
                     </div>
 
@@ -1423,6 +1523,17 @@ export default function DraftPage() {
         playerType={profilePlayerType}
         onClose={closePlayerInfo}
       />
+
+      {noteTarget && (
+        <PlayerNotePopover
+          open={true}
+          playerName={noteTarget.name}
+          initialNote={notes[noteTarget.id] ?? ""}
+          saving={noteSaving}
+          onSave={handleNoteSave}
+          onClose={closeNoteModal}
+        />
+      )}
 
       {saveModalOpen && (
         <div className="fixed inset-0 z-[80] grid place-items-center p-4">

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -129,6 +129,16 @@ export interface SessionDetail {
 }
 
 /**
+ * PlayerNote: 선수 메모. 세션당 (session_id, player_id) 조합으로 유니크.
+ * - GET /api/draft/sessions/{id}/notes 응답 items 요소
+ */
+export type PlayerNote = {
+  playerId: string;
+  note: string;
+  updatedAt: string;
+};
+
+/**
  * DraftSort: 드래프트 페이지의 정렬 옵션
  * - _desc: 내림차순 (높은 것부터)
  * - _asc: 오름차순


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Added a `PlayerNote` type to `fe/src/types/draft.ts` (`{ playerId, note, updatedAt }`) mirroring the new backend payload shape.
- Created `fe/src/features/draft/components/PlayerNotePopover.tsx` — a fixed-position popover with a 1000-char textarea, auto-focus on open, Save/Cancel buttons, and a "save empty to delete" hint. Save is disabled when the draft text matches the saved value.
- Wired notes end-to-end in `fe/src/pages/DraftPage.tsx`:
  - New state `notes: Record<playerId, string>` plus a popover target + saving flag.
  - On loaded-session mount, `GET /api/draft/sessions/{id}/notes` populates the map (separate effect, cleans state when leaving loaded mode).
  - Added a small memo icon next to each player name in the player row — outline/grey when empty, amber-filled when a note exists.
  - The icon is disabled in unsaved (no-session) mode with the tooltip "Save your draft first to add notes", and also disabled for unauthenticated users.
  - Save handler calls `PUT /api/draft/sessions/{id}/notes/{playerId}` and updates local state on success; on failure a toast is shown.

## Why
<!-- Why did you do it? -->
- Users wanted somewhere to jot personal scouting notes next to a player during a live draft (injury watch, max-bid reminders, keeper candidacy, etc.). Putting the trigger right next to the player name was the chosen surface in the UX discussion — the icon stays visible the entire time the user is scanning the player list.
- A per-session scope was preferred over a global scope because the same player can have very different planning notes in different leagues (e.g. "fade in AL keeper league" vs "core target in NL $260").
- Inline popover (vs full modal vs Player Info tab) was chosen for discoverability and zero page-context loss — clicking the icon and saving is a 2-click round-trip without leaving the player list.
- The icon is intentionally disabled in unsaved mode rather than buffering edits to localStorage: notes are tied to a `session_id` server-side, and shipping a quiet-store-then-flush path would have doubled the wiring for an edge case (unsaved drafts get saved within minutes anyway).

## Related Issue
<!-- e.g. #123 -->
- #94