### PR TITLE
feature: minor, taxi draft implementation

### DIFF
--- a/fe/src/features/draft/components/DraftRoomBoard.tsx
+++ b/fe/src/features/draft/components/DraftRoomBoard.tsx
@@ -1,23 +1,40 @@
 import { useMemo, useRef, useState } from "react";
-import type { DraftPick, DraftPlayer, DraftTeam } from "../../../types/draft";
-import { isEligibleForSlot, teamAccentClass } from "../utils";
+import type { DraftPick, DraftPickKind, DraftPlayer, DraftTeam } from "../../../types/draft";
+import { MINOR_TAXI_SLOT_COUNT, isEligibleForSlot, teamAccentClass } from "../utils";
 
 type Props = {
   teams: DraftTeam[];
-  slotTemplate: string[];
-  picks: DraftPick[];
+  slotTemplate: string[];                 // 메인 보드 슬롯 (마이너/택시는 컴포넌트가 자체 생성)
+  picks: DraftPick[];                     // 모든 kind 통합 — 컴포넌트가 view 로 필터
   playersById: Record<string, DraftPlayer>;
   currentRound: number;
   totalRounds: number;
   authed: boolean;
   myTeamId: string | null;
+  view: DraftPickKind;                    // 현재 보고 있는 보드
+  onViewChange: (next: DraftPickKind) => void;
   onRemovePick: (pick: DraftPick) => void;
   // 내 팀 안에서 드래그-드롭으로 슬롯 인덱스를 바꿀 때 호출.
-  onSlotReassign?: (fromIndex: number, toIndex: number) => void;
+  // 마이너/택시는 자격 검사 없이 순수 재정렬.
+  onSlotReassign?: (fromIndex: number, toIndex: number, kind: DraftPickKind) => void;
 };
 
 // Drag payload: 자기 팀의 어떤 슬롯에서 출발했는지.
 const DRAG_MIME = "application/x-ppadun-slot";
+
+// 보드 탭. 항상 3개 모두 노출하고 현재 view 만 강조.
+const ALL_TABS: { key: DraftPickKind; label: string }[] = [
+  { key: "minor", label: "Minor" },
+  { key: "main", label: "Main" },
+  { key: "taxi", label: "Taxi" },
+];
+
+// 보드별 헤더 텍스트.
+const BOARD_HEADER: Record<DraftPickKind, { title: string; subtitle: string }> = {
+  main: { title: "Draft Room", subtitle: "Live draft status by team" },
+  minor: { title: "Minor Draft", subtitle: "Free picks before main draft" },
+  taxi: { title: "Taxi Draft", subtitle: "Free taxi-squad picks" },
+};
 
 export default function DraftRoomBoard({
   teams,
@@ -28,6 +45,8 @@ export default function DraftRoomBoard({
   totalRounds,
   authed,
   myTeamId,
+  view,
+  onViewChange,
   onRemovePick,
   onSlotReassign,
 }: Props) {
@@ -38,10 +57,12 @@ export default function DraftRoomBoard({
   // 드래그가 hover 중인 슬롯 — 자격 여부에 따라 테두리 색을 다르게 칠한다.
   const [hoverTarget, setHoverTarget] = useState<{ index: number; ok: boolean } | null>(null);
 
+  // 현재 보드에 해당하는 픽만 추려서 팀별로 정렬.
   const picksByTeam = useMemo(() => {
     const map = new Map<string, DraftPick[]>();
     for (const team of teams) map.set(team.id, []);
     for (const pick of picks) {
+      if (pick.kind !== view) continue;
       const arr = map.get(pick.draftedByTeamId);
       if (arr) arr.push(pick);
     }
@@ -49,7 +70,16 @@ export default function DraftRoomBoard({
       arr.sort((a, b) => a.slotIndex - b.slotIndex);
     }
     return map;
-  }, [teams, picks]);
+  }, [teams, picks, view]);
+
+  // view 에 따라 슬롯 템플릿 선택. 마이너/택시는 8개 평면 슬롯 (라벨 없음).
+  const effectiveSlotTemplate = useMemo(
+    () =>
+      view === "main"
+        ? slotTemplate
+        : Array(MINOR_TAXI_SLOT_COUNT).fill("") as string[],
+    [view, slotTemplate]
+  );
 
   const canScroll = teams.length > 7;
 
@@ -64,34 +94,69 @@ export default function DraftRoomBoard({
 
   if (!authed) return null;
 
-  // 출발 슬롯의 player 가 target 슬롯에 자격이 있는지 확인 (드래그 hover 시각화 용).
+  // 출발 슬롯의 player 가 target 슬롯에 자격이 있는지 확인 (메인만 의미 있음).
+  // 마이너/택시는 슬롯 자격 자체가 없으니 항상 OK.
   const isHoverEligible = (toIndex: number): boolean => {
     if (draggingFrom === null || !myTeamId) return false;
     if (draggingFrom === toIndex) return true;
+    if (view !== "main") return true;
+
     const fromPick = (picksByTeam.get(myTeamId) ?? []).find(
       (p) => p.slotIndex === draggingFrom
     );
     if (!fromPick) return false;
     const player = playersById[fromPick.playerId];
     if (!player) return false;
-    const toSlotPos = slotTemplate[toIndex];
+    const toSlotPos = effectiveSlotTemplate[toIndex];
     if (!toSlotPos) return false;
     return isEligibleForSlot(player.positions, toSlotPos);
   };
 
+  const header = BOARD_HEADER[view];
+  const isMainView = view === "main";
+
   return (
-    <section className="rounded-3xl border border-white/10 bg-white/5 p-4">
+    <section className="relative mt-10 rounded-3xl border border-white/10 bg-white/5 p-4">
+      {/* 상단 중앙에 붙은 탭 — 항상 3개 노출, 활성 탭은 박스와 한 면처럼 이어진다 */}
+      <div className="absolute left-1/2 top-0 z-10 flex -translate-x-1/2 -translate-y-full">
+        {ALL_TABS.map((tab) => {
+          const isActive = tab.key === view;
+          return (
+            <button
+              key={tab.key}
+              type="button"
+              onClick={() => onViewChange(tab.key)}
+              className={[
+                "rounded-t-xl border border-white/10 px-5 py-1.5 text-xs font-black uppercase tracking-wider transition",
+                isActive
+                  ? // 활성: 박스 내부와 동일한 불투명 색(#000 위 white/5 합성값)으로 보더를 완전 가림. 안쪽 위 하이라이트로 살짝 입체.
+                    "relative z-10 translate-y-px border-b-0 bg-[#0d0d0d] text-white shadow-[inset_0_1px_0_0_rgba(255,255,255,0.12)]"
+                  : "border-b-0 bg-white/[0.02] text-white/45 hover:bg-white/[0.05] hover:text-white/75",
+              ].join(" ")}
+              title={`Switch to ${tab.label} draft`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
       <div className="mb-4 flex items-center justify-between gap-3">
         <div>
-          <div className="text-sm font-black text-white">Draft Room</div>
+          <div className="text-sm font-black text-white">{header.title}</div>
           <div className="mt-1 text-xs text-white/55">
-            Live draft status by team | {totalRounds} roster slots each
+            {header.subtitle}
+            {isMainView
+              ? ` | ${totalRounds} roster slots each`
+              : ` | ${MINOR_TAXI_SLOT_COUNT} slots each`}
           </div>
         </div>
 
-        <div className="text-sm font-black text-emerald-400">
-          Round {currentRound} / {totalRounds}
-        </div>
+        {isMainView && (
+          <div className="text-sm font-black text-emerald-400">
+            Round {currentRound} / {totalRounds}
+          </div>
+        )}
       </div>
 
       <div className="relative">
@@ -141,7 +206,7 @@ export default function DraftRoomBoard({
                   </div>
 
                   <div className="space-y-2">
-                    {slotTemplate.map((slotPos, slotIndex) => {
+                    {effectiveSlotTemplate.map((slotPos, slotIndex) => {
                       const pick = teamPicks.find((p) => p.slotIndex === slotIndex);
                       const player = pick ? playersById[pick.playerId] : null;
 
@@ -179,7 +244,7 @@ export default function DraftRoomBoard({
                               if (!raw) return;
                               const fromIndex = Number(raw);
                               if (Number.isFinite(fromIndex)) {
-                                onSlotReassign?.(fromIndex, slotIndex);
+                                onSlotReassign?.(fromIndex, slotIndex, view);
                               }
                             },
                           }
@@ -226,16 +291,27 @@ export default function DraftRoomBoard({
                               x
                             </button>
 
-                            <div className="text-[9px] font-extrabold uppercase tracking-wide text-white/40">
-                              {slotPos}
-                            </div>
+                            {/* 마이너/택시는 포지션 라벨 없이 슬롯 번호만 */}
+                            {isMainView ? (
+                              <div className="text-[9px] font-extrabold uppercase tracking-wide text-white/40">
+                                {slotPos}
+                              </div>
+                            ) : (
+                              <div className="text-[9px] font-extrabold uppercase tracking-wide text-white/40">
+                                Slot {slotIndex + 1}
+                              </div>
+                            )}
                             <div className="pr-5 text-[11px] font-black text-white">
                               {slotIndex + 1}. {player.name}
                             </div>
                             <div className="mt-1 flex items-center gap-2 text-[10px] text-white/55">
                               <span>{player.team}</span>
-                              <span>|</span>
-                              <span>${pick.bid ?? "?"}</span>
+                              {isMainView && (
+                                <>
+                                  <span>|</span>
+                                  <span>${pick.bid ?? "?"}</span>
+                                </>
+                              )}
                             </div>
                           </div>
                         );
@@ -250,9 +326,15 @@ export default function DraftRoomBoard({
                             hoverRingClass,
                           ].join(" ")}
                         >
-                          <div className="text-[9px] font-extrabold uppercase tracking-wide text-white/40">
-                            {slotPos}
-                          </div>
+                          {isMainView ? (
+                            <div className="text-[9px] font-extrabold uppercase tracking-wide text-white/40">
+                              {slotPos}
+                            </div>
+                          ) : (
+                            <div className="text-[9px] font-extrabold uppercase tracking-wide text-white/40">
+                              Slot {slotIndex + 1}
+                            </div>
+                          )}
                           <div className="mt-0.5 text-white/30">Empty</div>
                         </div>
                       );

--- a/fe/src/features/draft/components/TakenBidModal.tsx
+++ b/fe/src/features/draft/components/TakenBidModal.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { DraftPlayer, DraftTeam } from "../../../types/draft";
+import type { DraftPickKind, DraftPlayer, DraftTeam } from "../../../types/draft";
 
 type Props = {
   open: boolean;
   player: DraftPlayer | null;
   teams: DraftTeam[];
   remainingBudgetByTeam: Record<string, number>;
+  // 마이너/택시 보드는 bid 가 없음 — 입력 필드/검증 건너뛰고 bid=null 로 confirm.
+  kind?: DraftPickKind;
   onClose: () => void;
-  onConfirm: (draftedByTeamId: string, bid: number) => void;
+  onConfirm: (draftedByTeamId: string, bid: number | null) => void;
 };
 
 export default function TakenBidModal({
@@ -15,9 +17,11 @@ export default function TakenBidModal({
   player,
   teams,
   remainingBudgetByTeam,
+  kind = "main",
   onClose,
   onConfirm,
 }: Props) {
+  const isMainKind = kind === "main";
   const otherTeams = useMemo(() => teams.filter((t) => !t.isMine), [teams]);
 
   const initialTeamId = useMemo(() => otherTeams[0]?.id ?? "", [otherTeams]);
@@ -75,6 +79,11 @@ export default function TakenBidModal({
 
   const handleConfirm = () => {
     if (!validTeam) return;
+    // 마이너/택시는 bid 가 없으니 그대로 confirm.
+    if (!isMainKind) {
+      onConfirm(draftedByTeamId, null);
+      return;
+    }
     if (!Number.isFinite(parsedBid) || parsedBid < 1) {
       openMinBidError();
       return;
@@ -92,7 +101,11 @@ export default function TakenBidModal({
 
       <div className="relative mx-auto mt-24 w-[92%] max-w-md overflow-visible rounded-3xl border border-rose-400/25 bg-[#1b1112] shadow-2xl">
         <div className="rounded-t-3xl bg-rose-600 px-6 py-3 text-center text-sm font-black text-white">
-          Opponent Draft Bid
+          {isMainKind
+            ? "Opponent Draft Bid"
+            : kind === "minor"
+            ? "Opponent Minor Pick"
+            : "Opponent Taxi Pick"}
         </div>
 
         <div className="p-6">
@@ -126,44 +139,46 @@ export default function TakenBidModal({
               </select>
             </div>
 
-            <div className="border-t border-white/10 pt-4">
-              <div className="text-xs font-extrabold text-white/70">Winning Bid</div>
-              <div className="mt-2 flex items-center gap-2">
-                <input
-                  value={bid}
-                  onChange={(e) => setBid(e.target.value)}
-                  inputMode="numeric"
-                  placeholder="Enter winning bid"
-                  className={[
-                    "w-full rounded-2xl bg-black/30 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35",
-                    bidInputErrorOpen
-                      ? "border border-rose-500 ring-1 ring-rose-400/80"
-                      : "border border-white/10 focus:border-rose-400/35",
-                  ].join(" ")}
-                />
-                <div className="grid h-12 w-12 place-items-center rounded-2xl bg-white/10 text-sm font-black text-white/60">
-                  $
+            {isMainKind && (
+              <div className="border-t border-white/10 pt-4">
+                <div className="text-xs font-extrabold text-white/70">Winning Bid</div>
+                <div className="mt-2 flex items-center gap-2">
+                  <input
+                    value={bid}
+                    onChange={(e) => setBid(e.target.value)}
+                    inputMode="numeric"
+                    placeholder="Enter winning bid"
+                    className={[
+                      "w-full rounded-2xl bg-black/30 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35",
+                      bidInputErrorOpen
+                        ? "border border-rose-500 ring-1 ring-rose-400/80"
+                        : "border border-white/10 focus:border-rose-400/35",
+                    ].join(" ")}
+                  />
+                  <div className="grid h-12 w-12 place-items-center rounded-2xl bg-white/10 text-sm font-black text-white/60">
+                    $
+                  </div>
+                </div>
+
+                {minBidErrorOpen && (
+                  <div className="relative mt-2 inline-block rounded-xl bg-rose-500 px-3 py-2 text-xs font-bold text-white shadow-lg">
+                    <span className="absolute -top-1 left-4 h-2 w-2 rotate-45 bg-rose-500" />
+                    Winning bid must be at least $1.
+                  </div>
+                )}
+
+                {budgetErrorOpen && (
+                  <div className="relative mt-2 inline-block rounded-xl bg-rose-500 px-3 py-2 text-xs font-bold text-white shadow-lg">
+                    <span className="absolute -top-1 left-4 h-2 w-2 rotate-45 bg-rose-500" />
+                    Winning bid cannot exceed this team's remaining budget (${selectedTeamBudget}).
+                  </div>
+                )}
+
+                <div className="mt-2 text-xs text-white/35">
+                  Record the actual winning amount to track opponent budgets.
                 </div>
               </div>
-
-              {minBidErrorOpen && (
-                <div className="relative mt-2 inline-block rounded-xl bg-rose-500 px-3 py-2 text-xs font-bold text-white shadow-lg">
-                  <span className="absolute -top-1 left-4 h-2 w-2 rotate-45 bg-rose-500" />
-                  Winning bid must be at least $1.
-                </div>
-              )}
-
-              {budgetErrorOpen && (
-                <div className="relative mt-2 inline-block rounded-xl bg-rose-500 px-3 py-2 text-xs font-bold text-white shadow-lg">
-                  <span className="absolute -top-1 left-4 h-2 w-2 rotate-45 bg-rose-500" />
-                  Winning bid cannot exceed this team's remaining budget (${selectedTeamBudget}).
-                </div>
-              )}
-
-              <div className="mt-2 text-xs text-white/35">
-                Record the actual winning amount to track opponent budgets.
-              </div>
-            </div>
+            )}
           </div>
 
           <div className="mt-8 flex gap-3">

--- a/fe/src/features/draft/utils.ts
+++ b/fe/src/features/draft/utils.ts
@@ -178,31 +178,59 @@ export function calculateRemainingBudget(budget: number, myTeamId: string, picks
   return Math.max(0, budget - spent);
 }
 
-/** Current draft round (1-based), capped at total rounds. */
+/** Current draft round (1-based), capped at total rounds.
+ *  마이너/택시 픽은 메인 진행도에 영향을 주지 않으므로 카운트에서 제외. */
 export function calculateCurrentRound(teamCount: number, rosterSlots: number, picks: DraftPick[]) {
-  return Math.min(rosterSlots, Math.floor(picks.length / teamCount) + 1);
+  const mainCount = picks.filter((p) => p.kind === "main").length;
+  return Math.min(rosterSlots, Math.floor(mainCount / teamCount) + 1);
 }
 
-/** Check if player is available, drafted by me, or taken by opponent. */
+/** 마이너/택시 보드의 슬롯 개수. 메인과 달리 포지션 라벨 없는 평면 슬롯. */
+export const MINOR_TAXI_SLOT_COUNT = 8;
+
+/** 마이너/택시처럼 자격 검사가 없는 보드에서 occupied 가 아닌 첫 빈 슬롯을 반환. 없으면 -1. */
+export function findFirstEmptySlot(occupied: Set<number>, count: number): number {
+  for (let i = 0; i < count; i += 1) {
+    if (!occupied.has(i)) return i;
+  }
+  return -1;
+}
+
+/** Check if player is available, drafted by me, or taken by opponent.
+ *  pickKind 를 함께 노출해 호출 측이 (minor)/(taxi) 프리픽스를 붙일 수 있게 한다. */
 export function getPlayerDraftStatus(playerId: string, picks: DraftPick[], teams: DraftTeam[]) {
   const hit = picks.find((p) => p.playerId === playerId);
   if (!hit) return { kind: "available" as const };
 
   const team = teams.find((t) => t.id === hit.draftedByTeamId);
-  const bidLabel = hit.bid ?? "?";
+  const teamName = team?.name ?? (hit.type === "mine" ? "My Team" : "Taken");
+  const pickKind = hit.kind ?? "main";
 
+  if (pickKind !== "main") {
+    const boardLabel = pickKind === "minor" ? "Minor" : "Taxi";
+    return {
+      kind: hit.type, // "mine" | "taken" — 기존 분기 그대로
+      pickKind,
+      label: `${boardLabel} - ${teamName}`,
+      teamName,
+    } as const;
+  }
+
+  const bidLabel = hit.bid ?? "?";
   if (hit.type === "mine") {
     return {
       kind: "mine" as const,
+      pickKind: "main" as const,
       label: `My Pick - $${bidLabel}`,
-      teamName: team?.name ?? "My Team",
+      teamName,
     };
   }
 
   return {
     kind: "taken" as const,
-    label: `${team?.name ?? "Taken"} - $${bidLabel}`,
-    teamName: team?.name ?? "Taken",
+    pickKind: "main" as const,
+    label: `${teamName} - $${bidLabel}`,
+    teamName,
   };
 }
 

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -24,6 +24,7 @@ import { apiGet, apiGetAuth, apiPostAuth, apiPutAuth, apiDeleteAuth } from "../l
 import type {
   DraftConfigServer,
   DraftPick,
+  DraftPickKind,
   DraftPlayer,
   DraftPlayerPublic,
   DraftPlayerValue,
@@ -37,12 +38,14 @@ type DraftPosition = DraftPlayer["positions"][number];
 
 import {
   DEFAULT_ROSTER_SLOTS,
+  MINOR_TAXI_SLOT_COUNT,
   buildSlotTemplateFromCounts,
   calculateCurrentRound,
   calculateRemainingBudget,
   clampRosterSize,
   draftCostClass,
   findEligibleSlotIndex,
+  findFirstEmptySlot,
   formatAvg,
   getPlayerDraftStatus,
   isEligibleForSlot,
@@ -213,10 +216,12 @@ function normalizeDraftTeamId(teamId: string) {
   return teamId;
 }
 
-function normalizeDraftPicks(picks: DraftPick[]) {
+function normalizeDraftPicks(picks: DraftPick[]): DraftPick[] {
   return picks.map((pick) => ({
     ...pick,
     draftedByTeamId: normalizeDraftTeamId(pick.draftedByTeamId),
+    // 옛 localStorage / 세션엔 kind 가 없을 수 있어 main 폴백.
+    kind: pick.kind ?? "main",
   }));
 }
 
@@ -315,6 +320,10 @@ export default function DraftPage() {
   const [comparisonOpen, setComparisonOpen] = useState(false);
   const [profilePlayerId, setProfilePlayerId] = useState<number | null>(null);
   const [profilePlayerType, setProfilePlayerType] = useState<"batter" | "pitcher">("batter");
+
+  // 현재 보고 있는 보드 — 메인/마이너/택시. DraftRoomBoard 의 포스트잇 탭으로 전환.
+  // Add/Taken 액션은 이 view 의 kind 로 픽을 생성한다.
+  const [boardView, setBoardView] = useState<DraftPickKind>("main");
 
   const [addTarget, setAddTarget] = useState<DraftPlayer | null>(null);
   const [takenTarget, setTakenTarget] = useState<DraftPlayer | null>(null);
@@ -700,21 +709,38 @@ export default function DraftPage() {
   };
 
   // 내 팀 보드 안에서 드래그로 슬롯을 옮길 때:
-  //   - 대상이 비어 있으면 자격(isEligibleForSlot) 만 만족하면 이동
-  //   - 대상이 차 있으면 양방향 자격(둘 다 상대 슬롯에 들어갈 수 있음)일 때만 swap
-  //   - 그 외에는 toast 로 사유 설명
-  const handleSlotReassign = (fromIndex: number, toIndex: number) => {
+  //   - 메인: 자격(isEligibleForSlot) 검사 후 이동/스왑.
+  //   - 마이너/택시: 포지션 자격이 없으니 순수 재정렬(스왑/빈자리 이동).
+  // kind 는 어느 보드의 슬롯을 만지는지 — 같은 kind 내에서만 인덱스 충돌이 발생.
+  const handleSlotReassign = (fromIndex: number, toIndex: number, kind: DraftPickKind) => {
     if (fromIndex === toIndex) return;
     const myTeamId = myTeam?.id;
     if (!myTeamId) return;
+
+    const myPicks = picks.filter(
+      (p) => p.draftedByTeamId === myTeamId && p.kind === kind
+    );
+    const fromPick = myPicks.find((p) => p.slotIndex === fromIndex);
+    if (!fromPick) return;
+    const toPick = myPicks.find((p) => p.slotIndex === toIndex);
+
+    // 마이너/택시: 자격 검사 없이 그냥 스왑/이동.
+    if (kind !== "main") {
+      commitPicks((prev) =>
+        prev.map((p) => {
+          if (p.kind !== kind) return p;
+          if (p.playerId === fromPick.playerId) return { ...p, slotIndex: toIndex };
+          if (toPick && p.playerId === toPick.playerId) return { ...p, slotIndex: fromIndex };
+          return p;
+        })
+      );
+      return;
+    }
 
     const fromSlotPos = slotTemplate[fromIndex];
     const toSlotPos = slotTemplate[toIndex];
     if (!fromSlotPos || !toSlotPos) return;
 
-    const myPicks = picks.filter((p) => p.draftedByTeamId === myTeamId);
-    const fromPick = myPicks.find((p) => p.slotIndex === fromIndex);
-    if (!fromPick) return;
     const fromPlayer = playersById[fromPick.playerId];
     if (!fromPlayer) return;
 
@@ -722,8 +748,6 @@ export default function DraftPage() {
       pushToast(`${fromPlayer.name} is not eligible for ${toSlotPos}.`, "error");
       return;
     }
-
-    const toPick = myPicks.find((p) => p.slotIndex === toIndex);
 
     // Empty target → simple move.
     if (!toPick) {
@@ -760,20 +784,47 @@ export default function DraftPage() {
     );
   };
 
-  // 옵션 A: 픽 추가 시 클라이언트가 즉시 slotIndex 결정.
-  // 같은 playerId 의 기존 픽은 제외 → 같은 팀 occupied 슬롯 집합 → findAvailableSlotIndex.
+  // 픽 추가 시 클라이언트가 즉시 slotIndex 결정.
+  // 같은 playerId 의 기존 픽은 제외 → 같은 팀+kind occupied 슬롯 집합 → 빈 슬롯 찾기.
+  // 메인은 포지션 자격 매칭, 마이너/택시는 그냥 첫 빈 자리.
   // -1 이면 자리 없음 알림 후 종료.
   const addPickToState = (
     playerId: string,
     draftedByTeamId: string,
-    bid: number,
-    type: DraftPick["type"]
+    bid: number | null,
+    type: DraftPick["type"],
+    kind: DraftPickKind
   ) => {
     const filtered = picks.filter((p) => p.playerId !== playerId);
     const occupied = new Set(
-      filtered.filter((p) => p.draftedByTeamId === draftedByTeamId).map((p) => p.slotIndex)
+      filtered
+        .filter((p) => p.draftedByTeamId === draftedByTeamId && p.kind === kind)
+        .map((p) => p.slotIndex)
     );
     const player = playersById[playerId];
+
+    if (kind !== "main") {
+      const slotIndex = findFirstEmptySlot(occupied, MINOR_TAXI_SLOT_COUNT);
+      if (slotIndex === -1) {
+        pushToast(
+          `No empty ${kind} slot for ${player?.name ?? "this player"}.`,
+          "error"
+        );
+        return false;
+      }
+      const next: DraftPick = {
+        playerId,
+        draftedByTeamId,
+        slotIndex,
+        slotPos: null,
+        bid: null,
+        type,
+        kind,
+      };
+      commitPicks([...filtered, next]);
+      return true;
+    }
+
     const slotIndex = findEligibleSlotIndex(
       player?.positions,
       slotTemplate,
@@ -788,21 +839,41 @@ export default function DraftPage() {
     }
 
     const slotPos = (slotTemplate[slotIndex] ?? "BENCH") as DraftPosition;
-    const next: DraftPick = { playerId, draftedByTeamId, slotIndex, slotPos, bid, type };
+    const next: DraftPick = {
+      playerId,
+      draftedByTeamId,
+      slotIndex,
+      slotPos,
+      bid,
+      type,
+      kind: "main",
+    };
     commitPicks([...filtered, next]);
     return true;
   };
 
+  // Add 버튼 클릭 — 메인이면 bid 모달, 마이너/택시는 바로 추가.
+  const handleAddClick = (player: DraftPlayer) => {
+    if (boardView !== "main") {
+      if (!myTeam) return;
+      if (addPickToState(player.id, myTeam.id, null, "mine", boardView)) {
+        draftRoomTopRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
+      return;
+    }
+    openAddModal(player);
+  };
+
   const handleAddFinish = (bid: number) => {
     if (!addTarget || !myTeam) return;
-    if (!addPickToState(addTarget.id, myTeam.id, bid, "mine")) return;
+    if (!addPickToState(addTarget.id, myTeam.id, bid, "mine", "main")) return;
     closeAddModal();
     draftRoomTopRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
-  const handleTakenFinish = (draftedByTeamId: string, bid: number) => {
+  const handleTakenFinish = (draftedByTeamId: string, bid: number | null) => {
     if (!takenTarget) return;
-    if (!addPickToState(takenTarget.id, draftedByTeamId, bid, "taken")) return;
+    if (!addPickToState(takenTarget.id, draftedByTeamId, bid, "taken", boardView)) return;
     closeTakenModal();
     draftRoomTopRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
@@ -1033,6 +1104,8 @@ export default function DraftPage() {
               totalRounds={rosterSize}
               authed={authed}
               myTeamId={myTeam?.id ?? null}
+              view={boardView}
+              onViewChange={setBoardView}
               onRemovePick={handleRemovePick}
               onSlotReassign={handleSlotReassign}
             />
@@ -1218,19 +1291,19 @@ export default function DraftPage() {
       <FadeIn delayMs={140}>
         <section className="overflow-hidden rounded-3xl border border-white/10 bg-white/5">
           <div className="grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_.9fr_1.3fr_1.1fr_.9fr] bg-black/40 px-4 py-3 text-xs font-extrabold text-white/60">
-            <div>#</div>
+            <div className="text-center">#</div>
             <div>Player</div>
-            <div>Pos</div>
-            <div>Draft Cost</div>
-            <div>Team</div>
-            <div>{statColumnLabels[0]}</div>
-            <div>{statColumnLabels[1]}</div>
-            <div>{statColumnLabels[2]}</div>
-            <div>{statColumnLabels[3]}</div>
-            <div>{statColumnLabels[4]}</div>
-            <div>PPA-DUN Value</div>
-            <div>Action</div>
-            <div>Compare</div>
+            <div className="text-center">Pos</div>
+            <div className="text-center">Cost</div>
+            <div className="text-center">Team</div>
+            <div className="text-center">{statColumnLabels[0]}</div>
+            <div className="text-center">{statColumnLabels[1]}</div>
+            <div className="text-center">{statColumnLabels[2]}</div>
+            <div className="text-center">{statColumnLabels[3]}</div>
+            <div className="text-center">{statColumnLabels[4]}</div>
+            <div className="text-center">PPA-Value</div>
+            <div className="text-center">Action</div>
+            <div className="text-center">Compare</div>
           </div>
 
           <div className="bg-black/20">
@@ -1259,33 +1332,34 @@ export default function DraftPage() {
                   <div
                     key={player.id}
                     className={[
-                      "grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_.9fr_1.3fr_1.1fr_.9fr] items-center px-4 py-3 text-sm text-white/85 transition",
+                      "grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_.9fr_1.3fr_1.1fr_.9fr] items-center px-4 py-3 text-sm text-white/85 transition tabular-nums",
                       compareActive
                         ? "relative z-[1] my-1 rounded-xl border border-emerald-400/75 bg-emerald-500/10 shadow-[0_0_18px_rgba(16,185,129,0.35)]"
                         : "hover:bg-white/5",
                     ].join(" ")}
                   >
-                    <div className="text-white/45">{(page - 1) * PAGE_SIZE + idx + 1}</div>
+                    <div className="text-center text-white/45">{(page - 1) * PAGE_SIZE + idx + 1}</div>
 
-                    <div>
+                    <div className="min-w-0">
                       <button
                         type="button"
                         onClick={() => openPlayerInfo(player.id, player.playerType)}
-                        className="rounded-md border border-transparent px-2 py-1 -mx-2 -my-1 font-semibold text-white transition hover:border-white/35 hover:bg-white/5 hover:text-amber-200 focus-visible:border-white/45 focus-visible:bg-white/10 focus-visible:outline-none"
+                        className="block w-full truncate rounded-md border border-transparent px-2 py-1 -mx-2 -my-1 text-left font-semibold text-white transition hover:border-white/35 hover:bg-white/5 hover:text-amber-200 focus-visible:border-white/45 focus-visible:bg-white/10 focus-visible:outline-none"
+                        title={player.name}
                       >
                         {player.name}
                       </button>
                     </div>
 
-                    <div>
-                      <span className="rounded-lg bg-white/10 px-2 py-1 text-[11px] font-extrabold text-white/80">
+                    <div className="text-center">
+                      <span className="inline-block rounded-lg bg-white/10 px-2 py-1 text-[11px] font-extrabold text-white/80">
                         {player.positions[0]}
                       </span>
                     </div>
 
-                    <div className={draftCostClass(authed)}>${player.recommendedBid ?? "—"}</div>
+                    <div className={`text-center ${draftCostClass(authed)}`}>${player.recommendedBid ?? "—"}</div>
 
-                    <div>
+                    <div className="text-center">
                       <span
                         className={[
                           "inline-flex items-center rounded-lg border px-2 py-1 text-[11px] font-extrabold",
@@ -1296,28 +1370,33 @@ export default function DraftPage() {
                       </span>
                     </div>
 
-                    <div className="text-white/70">
+                    <div className="text-center text-white/70">
                       {isPitcherOnly(player) ? formatNumber(player.era, 2) : formatAvg(player.avg)}
                     </div>
-                    <div className="font-semibold text-amber-300">
+                    <div className="text-center font-semibold text-amber-300">
                       {isPitcherOnly(player) ? player.so ?? "-" : player.hr ?? "-"}
                     </div>
-                    <div className="text-white/70">
+                    <div className="text-center text-white/70">
                       {isPitcherOnly(player) ? player.w ?? "-" : player.rbi ?? "-"}
                     </div>
-                    <div className="font-semibold text-amber-300">
+                    <div className="text-center font-semibold text-amber-300">
                       {isPitcherOnly(player) ? player.sv ?? "-" : player.sb ?? "-"}
                     </div>
-                    <div className="text-white/70">
+                    <div className="text-center text-white/70">
                       {isPitcherOnly(player) ? formatNumber(player.ip, 1) : player.ab ?? "-"}
                     </div>
 
-                    <div className={`font-black ${ppaValueClass(player.ppaValue, { authed })}`}>
+                    <div className={`text-center font-black ${ppaValueClass(player.ppaValue, { authed })}`}>
                       {formatPpa(player.ppaValue)}
                     </div>
 
-                    <div className="flex items-center gap-2">
-                      {status.kind === "mine" ? (
+                    <div className="flex items-center justify-center gap-2">
+                      {status.kind !== "available" && status.pickKind !== "main" ? (
+                        // 마이너/택시 픽은 메인의 mine/taken 색감과 구분하기 위해 amber 톤.
+                        <div className="rounded-xl bg-amber-500/15 px-3 py-2 text-xs font-black text-amber-200 ring-1 ring-amber-400/20">
+                          {status.label}
+                        </div>
+                      ) : status.kind === "mine" ? (
                         <div className="rounded-xl bg-sky-500/15 px-3 py-2 text-xs font-black text-sky-200 ring-1 ring-sky-400/20">
                           {status.label}
                         </div>
@@ -1328,7 +1407,7 @@ export default function DraftPage() {
                       ) : authed ? (
                         <>
                           <button
-                            onClick={() => openAddModal(player)}
+                            onClick={() => handleAddClick(player)}
                             className="rounded-xl bg-emerald-500/15 px-3 py-2 text-xs font-black text-emerald-200 ring-1 ring-emerald-400/20 transition hover:bg-emerald-500/25"
                           >
                             Add
@@ -1347,7 +1426,7 @@ export default function DraftPage() {
                       )}
                     </div>
 
-                    <div className="flex items-center justify-end">
+                    <div className="flex items-center justify-center">
                       <button
                         type="button"
                         disabled={!authed}
@@ -1400,15 +1479,16 @@ export default function DraftPage() {
 
       {takenTarget && (
         <TakenBidModal
-          key={`taken-${takenTarget.id}`}
+          key={`taken-${takenTarget.id}-${boardView}`}
           open={true}
-      player={takenTarget}
-      teams={teams}
-      remainingBudgetByTeam={remainingBudgetByTeam}
-      onClose={closeTakenModal}
-      onConfirm={handleTakenFinish}
-    />
-  )}
+          player={takenTarget}
+          teams={teams}
+          remainingBudgetByTeam={remainingBudgetByTeam}
+          kind={boardView}
+          onClose={closeTakenModal}
+          onConfirm={handleTakenFinish}
+        />
+      )}
 
       <PlayerComparisonModal
         open={comparisonOpen && Boolean(selectedA) && Boolean(selectedB)}

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -57,15 +57,23 @@ export type DraftTeam = {
 export type DraftPickType = "mine" | "taken";
 
 /**
+ * DraftPickKind: 어느 보드에 속한 픽인지 구분
+ * - main: 일반 드래프트 (포지션 슬롯 + bid)
+ * - minor / taxi: 메인 드래프트 전/후로 따로 잡는 무료 픽. 포지션·bid 없음.
+ */
+export type DraftPickKind = "main" | "minor" | "taxi";
+
+/**
  * DraftPick: 개별 드래프트 픽 정보
  */
 export type DraftPick = {
   playerId: string;              // 뽑은 선수 ID
   draftedByTeamId: string;       // 뽑은 팀 ID
   slotIndex: number;             // 로스터 슬롯 번호
-  slotPos: string;               // 슬롯 포지션 (예: "SP", "OF", "BENCH")
-  bid: number | null;            // 낙찰가 ($)
+  slotPos: string | null;        // 슬롯 포지션 — 마이너/택시는 null
+  bid: number | null;            // 낙찰가 ($) — 마이너/택시는 null
   type: DraftPickType;           // "mine" 또는 "taken"
+  kind: DraftPickKind;           // "main" | "minor" | "taxi"
 };
 
 /**


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Added Minor and Taxi tabbed boards to DraftRoomBoard, three tabs at the top center switch between Main / Minor / Taxi, with minor and taxi rendering 8 flat positionless slots (no bids, drag-reorder still works without eligibility checks).
- Introduced a kind field on DraftPick and wired it through end-to-end: types, utils (calculateCurrentRound ignores non-main picks, new findFirstEmptySlot helper, getPlayerDraftStatus exposes pickKind), DraftPage state + Add/Taken branching (minor/taxi skip the bid modal), TakenBidModal hides the bid field for non-main, and the main player list shows an amber Minor/Taxi - TeamName badge for picks made on those boards.
- Polished the player stats table: added tabular-nums, center-aligned the numeric and badge columns, truncated long player names, and renamed Draft Cost → Cost and PPA-DUN Value → PPA-Value.

## Why
<!-- Why did you do it? -->
- Minor and Taxi are separate stages of the same draft session (pre-draft minor, post-draft taxi), so sharing the existing team-grid board via a view prop and a kind discriminator avoided duplicating UI and keeps all picks in one synchronized source of truth.
- Reusing the existing "drafted" row state for minor/taxi picks, with just an amber badge in place of the bid one, automatically blocks those players from being re-drafted on the main board without needing any extra filter or visibility logic.

## Related Issue
<!-- e.g. #123 -->
- #85 
