### PR TITLE
feat: notification polling and toast in Draft Room

### DIFF
--- a/fe/src/hooks/useNotificationPolling.ts
+++ b/fe/src/hooks/useNotificationPolling.ts
@@ -1,0 +1,74 @@
+// 15초마다 백엔드 알림 폴링하는 훅.
+// - 첫 로드 시 lastSeenId가 없으면 가장 최근 알림 id만 기억하고 토스트는 안 띄움
+//   (몇 주치 알림이 한꺼번에 토스트로 폭주하는 거 방지)
+// - 그 이후엔 lastSeenId 이후의 모든 알림에 대해 onEvent 콜백 호출
+// - lastSeenId는 localStorage에 보관 → 페이지 닫았다 다시 열어도 catch-up
+import { useEffect, useRef } from "react";
+
+import { apiGetAuth } from "../lib/api";
+import type { NotificationEvent } from "../types/notifications";
+
+const POLL_INTERVAL_MS = 15_000;
+const LAST_SEEN_KEY = "ppadun_notif_last_seen_id";
+const FETCH_LIMIT = 50;
+
+type Response = { items: NotificationEvent[] };
+
+export function useNotificationPolling(
+  onEvent: (ev: NotificationEvent) => void,
+  enabled: boolean
+) {
+  // 콜백을 ref에 넣어둠 — 매 polling 호출이 최신 콜백을 보게 하면서도
+  // effect deps에 onEvent를 안 넣어 매 렌더마다 polling 재시작되는 일 방지.
+  const onEventRef = useRef(onEvent);
+  useEffect(() => {
+    onEventRef.current = onEvent;
+  }, [onEvent]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    const stored = localStorage.getItem(LAST_SEEN_KEY);
+    let lastSeenId: number | null = stored !== null ? Number(stored) : null;
+
+    const tick = async () => {
+      try {
+        const since = lastSeenId ?? 0;
+        const data = await apiGetAuth<Response>(
+          "/api/notifications/recent",
+          { since, limit: FETCH_LIMIT }
+        );
+        if (cancelled) return;
+
+        const items = data.items ?? [];
+        if (items.length === 0) return;
+
+        // 첫 응답이면 토스트 없이 lastSeen만 갱신 (초기 폭주 방지).
+        if (lastSeenId === null) {
+          const newestId = items[items.length - 1].id;
+          lastSeenId = newestId;
+          localStorage.setItem(LAST_SEEN_KEY, String(newestId));
+          return;
+        }
+
+        // 그 이후엔 각 새 이벤트마다 콜백.
+        for (const ev of items) {
+          onEventRef.current(ev);
+          if (ev.id > lastSeenId) lastSeenId = ev.id;
+        }
+        localStorage.setItem(LAST_SEEN_KEY, String(lastSeenId));
+      } catch (err) {
+        // 401, 5xx, 네트워크 끊김 등 — 다음 tick에 재시도하므로 조용히 처리.
+        if (!cancelled) console.warn("notification polling failed:", err);
+      }
+    };
+
+    tick(); // 마운트 시 즉시 한 번
+    const id = window.setInterval(tick, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [enabled]);
+}

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -61,6 +61,8 @@ import AddBidModal from "../features/draft/components/AddBidModal";
 import TakenBidModal from "../features/draft/components/TakenBidModal";
 import PlayerComparisonModal from "../features/draft/components/PlayerComparisonModal";
 import PlayerNotePopover from "../features/draft/components/PlayerNotePopover";
+import { useNotificationPolling } from "../hooks/useNotificationPolling";
+import type { NotificationEvent } from "../types/notifications";
 import PlayerInfoModal from "../features/players/components/PlayerInfoModal";
 import Pagination from "../features/players/components/Pagination";
 import Modal from "../components/ui/Modal";
@@ -336,6 +338,19 @@ export default function DraftPage() {
   const [notes, setNotes] = useState<Record<string, string>>({});
   const [noteTarget, setNoteTarget] = useState<DraftPlayer | null>(null);
   const [noteSaving, setNoteSaving] = useState(false);
+
+  // 부상/뎁스 변경 알림 받은 선수 id 집합 — 페이지 떠나기 전까지 row에 빨간 점 표시.
+  const [affectedPlayerIds, setAffectedPlayerIds] = useState<Set<string>>(new Set());
+
+  // 15초마다 백엔드 알림 폴링. 새 이벤트마다 toast + affectedPlayerIds 업데이트.
+  useNotificationPolling((ev: NotificationEvent) => {
+    pushToast(ev.message, "error");
+    setAffectedPlayerIds((prev) => {
+      const next = new Set(prev);
+      next.add(ev.player_id);
+      return next;
+    });
+  }, authed);
 
   // Save / Import 모달
   const [saveModalOpen, setSaveModalOpen] = useState(false);
@@ -1448,6 +1463,13 @@ export default function DraftPage() {
                     <div className="text-center text-white/45">{(page - 1) * PAGE_SIZE + idx + 1}</div>
 
                     <div className="min-w-0 flex items-center gap-1">
+                      {affectedPlayerIds.has(player.id) && (
+                        <span
+                          className="inline-block h-2 w-2 shrink-0 rounded-full bg-rose-500 animate-pulse"
+                          title="Recent update"
+                          aria-label="Recent update"
+                        />
+                      )}
                       <button
                         type="button"
                         onClick={() => openPlayerInfo(player.id, player.playerType)}

--- a/fe/src/types/notifications.ts
+++ b/fe/src/types/notifications.ts
@@ -1,0 +1,15 @@
+/**
+ * NotificationEvent: backend의 GET /api/notifications/recent 응답 items 요소.
+ *
+ * - 부상/뎁스 변경 자동 감지 또는 admin이 보낸 fake push로 생성됨
+ * - id 오름차순 정렬로 도착. FE는 마지막으로 본 id를 localStorage에 보관해
+ *   재접속 시 그 이후 알림만 catch-up 한다.
+ */
+export type NotificationEvent = {
+  id: number;
+  event_type: string;          // "INJURY" | "DEPTH" | "NEWS" etc
+  player_id: string;
+  player_name: string | null;
+  message: string;
+  created_at: string;          // ISO 8601
+};


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Added \`NotificationEvent\` type in \`fe/src/types/notifications.ts\` matching the backend payload (\`id\`, \`event_type\`, \`player_id\`, \`player_name\`, \`message\`, \`created_at\`).
- Created \`fe/src/hooks/useNotificationPolling.ts\` — polls \`GET /api/notifications/recent?since=<lastSeenId>\` every 15 seconds while \`enabled\`, persists \`lastSeenId\` to localStorage, fires an \`onEvent\` callback for each new row. First-load uses a skip-and-remember pattern so the user does not get spammed with old alerts on initial login.
- Wired the hook into \`fe/src/pages/DraftPage.tsx\`:
  - new \`affectedPlayerIds: Set<string>\` state
  - per event → \`pushToast(message, "error")\` and add player_id to the set
  - small rose-colored pulsing dot rendered next to the player name for any id in the set
- Hook is gated on \`authed\` so it only runs for logged-in users (the underlying endpoint requires a Bearer token).

## Why
<!-- Why did you do it? -->
- Closes the user-facing half of the player notification rubric items (\`Force notification via API\`, \`Draft Kit show pushed state\`, \`Notification system alert\`). The backend (notifications table + polling endpoint + admin/webhook entrypoints + 15-min delta detection) is already merged and deployed to dev.
- Polling (rather than SSE) keeps the entire pipeline as plain stateless HTTP — no nginx buffering tweaks, no JWT-in-query workaround, no in-process pub/sub. McKenna confirmed in Discord that fake status pushes earn credit and live pulling earns more; this pipeline delivers both: admin \`POST /admin/player-event\` on the Player API cascades into the notification stream within ~15 s, and the live path comes from the be cache refresh detecting real injury / depth deltas every 15 minutes.
- Skip-on-first-load was added after thinking through the bootstrap case where a fresh login would otherwise dump every historic notification as a toast.

## Related Issue
<!-- e.g. #123 -->
- Closes #99
- Backend: \`Ppa-Dun-project/PPA-DUN-be#90\`
- Player API: \`Ppa-Dun-project/PPA-DUN-api#124\`