### PR TITLE
customizable 5-stat columns + DnD slot reassign for all teams

### DIFF
--- a/fe/src/components/ui/Modal.tsx
+++ b/fe/src/components/ui/Modal.tsx
@@ -1,13 +1,29 @@
 import { type PropsWithChildren, useEffect } from "react";
 
+type Size = "default" | "large";
+
 type Props = PropsWithChildren<{
   open: boolean;
   title?: string;
   onClose: () => void;
   footer?: React.ReactNode;
+  // 기본 max-w-2xl. "large"는 max-w-4xl — 좌우 두 컬럼 레이아웃에 적합.
+  size?: Size;
 }>;
 
-export default function Modal({ open, title, onClose, children, footer }: Props) {
+const SIZE_CLASS: Record<Size, string> = {
+  default: "max-w-2xl",
+  large: "max-w-4xl",
+};
+
+export default function Modal({
+  open,
+  title,
+  onClose,
+  children,
+  footer,
+  size = "default",
+}: Props) {
   useEffect(() => {
     if (!open) return;
 
@@ -29,7 +45,12 @@ export default function Modal({ open, title, onClose, children, footer }: Props)
         onClick={onClose}
       />
       {/* panel — vertical margin lets long content scroll within the viewport */}
-      <div className="relative mx-auto my-10 w-[92%] max-w-2xl rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl">
+      <div
+        className={[
+          "relative mx-auto my-10 w-[92%] rounded-2xl border border-white/10 bg-zinc-950 p-6 shadow-2xl",
+          SIZE_CLASS[size],
+        ].join(" ")}
+      >
         <div className="flex items-start justify-between gap-4">
           <div>
             {title && <h3 className="text-lg font-semibold text-white">{title}</h3>}

--- a/fe/src/features/draft/components/CustomizeStatsModal.tsx
+++ b/fe/src/features/draft/components/CustomizeStatsModal.tsx
@@ -1,0 +1,255 @@
+// Modal that lets the user pick which 5 stat columns appear in the
+// draft page player list, separately for batters and pitchers.
+//
+// Save stays disabled until exactly 5 are selected. Picks are kept in
+// local draft state until the user clicks Save; cancelling reverts.
+//
+// Reorder uses native HTML5 drag-and-drop on the Selected list: drag
+// any item over another item to drop it into that position.
+
+import { useState } from "react";
+import Modal from "../../../components/ui/Modal";
+import {
+  STAT_COLUMN_COUNT,
+  getDefaultsForGroup,
+  getStatDef,
+  getStatsForGroup,
+  type StatGroup,
+} from "../statColumns";
+
+const DRAG_MIME = "application/x-ppadun-statkey";
+
+type Props = {
+  onClose: () => void;
+  batterCols: string[];
+  pitcherCols: string[];
+  onSave: (group: StatGroup, cols: string[]) => void;
+};
+
+// Parent renders this conditionally (`{open && <CustomizeStatsModal ... />}`)
+// so each open creates a fresh component instance — local draft state starts
+// from the saved selection without needing a useEffect sync.
+export default function CustomizeStatsModal({
+  onClose,
+  batterCols,
+  pitcherCols,
+  onSave,
+}: Props) {
+  const [tab, setTab] = useState<StatGroup>("batter");
+  const [draftBatter, setDraftBatter] = useState<string[]>(batterCols);
+  const [draftPitcher, setDraftPitcher] = useState<string[]>(pitcherCols);
+  // Drag-and-drop: source index in the Selected list, and current hover index.
+  const [draggingIdx, setDraggingIdx] = useState<number | null>(null);
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+
+  const selected = tab === "batter" ? draftBatter : draftPitcher;
+  const setSelected = (next: string[]) => {
+    if (tab === "batter") setDraftBatter(next);
+    else setDraftPitcher(next);
+  };
+
+  const allInGroup = getStatsForGroup(tab);
+  const available = allInGroup.filter((s) => !selected.includes(s.key));
+  const isFull = selected.length === STAT_COLUMN_COUNT;
+  const canSave =
+    draftBatter.length === STAT_COLUMN_COUNT &&
+    draftPitcher.length === STAT_COLUMN_COUNT;
+
+  const addKey = (key: string) => {
+    if (isFull) return;
+    setSelected([...selected, key]);
+  };
+  const removeKey = (key: string) => setSelected(selected.filter((k) => k !== key));
+
+  const reorder = (from: number, to: number) => {
+    if (from === to || from < 0 || to < 0) return;
+    if (from >= selected.length || to >= selected.length) return;
+    const next = [...selected];
+    const [item] = next.splice(from, 1);
+    next.splice(to, 0, item);
+    setSelected(next);
+  };
+
+  const handleSave = () => {
+    if (!canSave) return;
+    onSave("batter", draftBatter);
+    onSave("pitcher", draftPitcher);
+    onClose();
+  };
+
+  const handleReset = () => {
+    // Local-only — actual persistence happens on Save, so Reset is
+    // safely undoable via Cancel.
+    setSelected([...getDefaultsForGroup(tab)]);
+  };
+
+  const counter = `${selected.length} / ${STAT_COLUMN_COUNT} selected`;
+  const counterColor = isFull ? "text-emerald-300" : "text-amber-300";
+  const helper = isFull
+    ? "Ready to save."
+    : `Pick ${STAT_COLUMN_COUNT - selected.length} more to save.`;
+
+  const footer = (
+    <>
+      <button
+        type="button"
+        onClick={onClose}
+        className="rounded-xl border border-white/15 bg-black/30 px-4 py-2 text-sm font-black text-white/80 transition hover:bg-white/5"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        onClick={handleSave}
+        disabled={!canSave}
+        className="rounded-xl border border-emerald-400/30 bg-emerald-500/15 px-4 py-2 text-sm font-black text-emerald-200 transition hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-emerald-500/15"
+      >
+        Save
+      </button>
+    </>
+  );
+
+  return (
+    <Modal size="large" title="Customize Stats" onClose={onClose} footer={footer} open={true}>
+      {/* Tab switcher */}
+      <div className="mb-5 flex gap-2">
+        {(["batter", "pitcher"] as const).map((g) => {
+          const active = tab === g;
+          const count = (g === "batter" ? draftBatter : draftPitcher).length;
+          return (
+            <button
+              key={g}
+              type="button"
+              onClick={() => setTab(g)}
+              className={[
+                "rounded-full px-5 py-2 text-sm font-extrabold transition",
+                active
+                  ? "bg-white text-black"
+                  : "border border-white/10 bg-white/5 text-white/75 hover:bg-white/10",
+              ].join(" ")}
+            >
+              {g === "batter" ? "Batter" : "Pitcher"} ({count}/{STAT_COLUMN_COUNT})
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
+        {/* Available */}
+        <div>
+          <div className="mb-2 text-xs font-black uppercase tracking-wide text-white/55">
+            Available ({available.length})
+          </div>
+          <div className="flex max-h-96 min-h-56 flex-wrap content-start gap-2 overflow-y-auto rounded-2xl border border-white/10 bg-black/30 p-4">
+            {available.length === 0 && (
+              <div className="text-sm text-white/50">All stats in this group are selected.</div>
+            )}
+            {available.map((s) => (
+              <button
+                key={s.key}
+                type="button"
+                onClick={() => addKey(s.key)}
+                disabled={isFull}
+                title={isFull ? "Remove one stat first" : `Add ${s.label}`}
+                className="rounded-full border border-white/10 bg-white/5 px-4 py-1.5 text-sm font-extrabold text-white/85 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white/5"
+              >
+                + {s.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Selected — drag to reorder */}
+        <div>
+          <div className="mb-2 flex items-baseline justify-between gap-2">
+            <span className="text-xs font-black uppercase tracking-wide text-white/55">
+              Selected
+            </span>
+            <span className={`text-xs font-extrabold ${counterColor}`}>{counter}</span>
+          </div>
+          <ol className="flex max-h-96 min-h-56 flex-col gap-1.5 overflow-y-auto rounded-2xl border border-white/10 bg-black/30 p-3">
+            {selected.length === 0 && (
+              <li className="p-2 text-sm text-white/50">No stats selected.</li>
+            )}
+            {selected.map((key, idx) => {
+              const def = getStatDef(key);
+              const isHover = hoverIdx === idx && draggingIdx !== null && draggingIdx !== idx;
+              const isDragging = draggingIdx === idx;
+              return (
+                <li
+                  key={key}
+                  draggable
+                  onDragStart={(e) => {
+                    e.dataTransfer.setData(DRAG_MIME, String(idx));
+                    e.dataTransfer.effectAllowed = "move";
+                    setDraggingIdx(idx);
+                  }}
+                  onDragEnd={() => {
+                    setDraggingIdx(null);
+                    setHoverIdx(null);
+                  }}
+                  onDragOver={(e) => {
+                    if (draggingIdx === null) return;
+                    e.preventDefault();
+                    e.dataTransfer.dropEffect = "move";
+                    if (hoverIdx !== idx) setHoverIdx(idx);
+                  }}
+                  onDragLeave={() => {
+                    if (hoverIdx === idx) setHoverIdx(null);
+                  }}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    const raw = e.dataTransfer.getData(DRAG_MIME);
+                    setHoverIdx(null);
+                    setDraggingIdx(null);
+                    if (!raw) return;
+                    const from = Number(raw);
+                    if (Number.isFinite(from)) reorder(from, idx);
+                  }}
+                  className={[
+                    "flex cursor-grab items-center gap-3 rounded-xl border bg-white/5 px-3 py-2 transition active:cursor-grabbing",
+                    isHover
+                      ? "border-emerald-400/60 ring-2 ring-emerald-400/40"
+                      : "border-white/10",
+                    isDragging ? "opacity-40" : "",
+                  ].join(" ")}
+                >
+                  <span className="select-none text-white/40" title="Drag to reorder" aria-hidden>
+                    ⋮⋮
+                  </span>
+                  <span className="w-5 text-center text-xs font-black text-white/45">
+                    {idx + 1}
+                  </span>
+                  <span className="flex-1 text-sm font-extrabold text-white">
+                    {def?.label ?? key}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => removeKey(key)}
+                    aria-label={`Remove ${def?.label ?? key}`}
+                    title="Remove"
+                    className="grid h-7 w-7 place-items-center rounded-md border border-rose-400/30 bg-rose-500/10 text-rose-200 transition hover:bg-rose-500/20"
+                  >
+                    ✕
+                  </button>
+                </li>
+              );
+            })}
+          </ol>
+        </div>
+      </div>
+
+      <div className="mt-4 flex items-center justify-between gap-3">
+        <p className={`text-sm ${isFull ? "text-white/55" : "text-amber-200"}`}>{helper}</p>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded-lg border border-white/10 bg-black/30 px-3 py-1.5 text-xs font-black text-white/70 transition hover:bg-white/5"
+          title={`Reset ${tab === "batter" ? "batter" : "pitcher"} selection to defaults`}
+        >
+          Reset to defaults
+        </button>
+      </div>
+    </Modal>
+  );
+}

--- a/fe/src/features/draft/components/DraftRoomBoard.tsx
+++ b/fe/src/features/draft/components/DraftRoomBoard.tsx
@@ -10,16 +10,21 @@ type Props = {
   currentRound: number;
   totalRounds: number;
   authed: boolean;
-  myTeamId: string | null;
   view: DraftPickKind;                    // 현재 보고 있는 보드
   onViewChange: (next: DraftPickKind) => void;
   onRemovePick: (pick: DraftPick) => void;
-  // 내 팀 안에서 드래그-드롭으로 슬롯 인덱스를 바꿀 때 호출.
+  // 한 팀 안에서 드래그-드롭으로 슬롯 인덱스를 바꿀 때 호출. (내 팀 + 상대 팀 모두)
+  // teamId 는 드래그가 일어난 팀 — 호출자가 어떤 팀의 픽을 재배치할지 결정하는 데 사용.
   // 마이너/택시는 자격 검사 없이 순수 재정렬.
-  onSlotReassign?: (fromIndex: number, toIndex: number, kind: DraftPickKind) => void;
+  onSlotReassign?: (
+    fromIndex: number,
+    toIndex: number,
+    kind: DraftPickKind,
+    teamId: string,
+  ) => void;
 };
 
-// Drag payload: 자기 팀의 어떤 슬롯에서 출발했는지.
+// Drag payload: { teamId, slotIndex } JSON. teamId 가 일치할 때만 drop 을 허용.
 const DRAG_MIME = "application/x-ppadun-slot";
 
 // 보드 탭. 항상 3개 모두 노출하고 현재 view 만 강조.
@@ -44,7 +49,6 @@ export default function DraftRoomBoard({
   currentRound,
   totalRounds,
   authed,
-  myTeamId,
   view,
   onViewChange,
   onRemovePick,
@@ -52,10 +56,14 @@ export default function DraftRoomBoard({
 }: Props) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
-  // 드래그 진행 중인 출발 슬롯 (내 팀 한정).
-  const [draggingFrom, setDraggingFrom] = useState<number | null>(null);
+  // 드래그 진행 중인 출발 슬롯 — 팀 안에서만 재배치하므로 teamId 도 함께 기억.
+  const [draggingFrom, setDraggingFrom] = useState<{ teamId: string; index: number } | null>(null);
   // 드래그가 hover 중인 슬롯 — 자격 여부에 따라 테두리 색을 다르게 칠한다.
-  const [hoverTarget, setHoverTarget] = useState<{ index: number; ok: boolean } | null>(null);
+  const [hoverTarget, setHoverTarget] = useState<{
+    teamId: string;
+    index: number;
+    ok: boolean;
+  } | null>(null);
 
   // 현재 보드에 해당하는 픽만 추려서 팀별로 정렬.
   const picksByTeam = useMemo(() => {
@@ -96,13 +104,15 @@ export default function DraftRoomBoard({
 
   // 출발 슬롯의 player 가 target 슬롯에 자격이 있는지 확인 (메인만 의미 있음).
   // 마이너/택시는 슬롯 자격 자체가 없으니 항상 OK.
-  const isHoverEligible = (toIndex: number): boolean => {
-    if (draggingFrom === null || !myTeamId) return false;
-    if (draggingFrom === toIndex) return true;
+  // teamId 는 hover 대상 팀 — 출발 팀과 같지 않으면 드롭 불가.
+  const isHoverEligible = (teamId: string, toIndex: number): boolean => {
+    if (draggingFrom === null) return false;
+    if (draggingFrom.teamId !== teamId) return false;
+    if (draggingFrom.index === toIndex) return true;
     if (view !== "main") return true;
 
-    const fromPick = (picksByTeam.get(myTeamId) ?? []).find(
-      (p) => p.slotIndex === draggingFrom
+    const fromPick = (picksByTeam.get(teamId) ?? []).find(
+      (p) => p.slotIndex === draggingFrom.index
     );
     if (!fromPick) return false;
     const player = playersById[fromPick.playerId];
@@ -189,7 +199,6 @@ export default function DraftRoomBoard({
             {teams.map((team, idx) => {
               const accent = teamAccentClass(team, idx);
               const teamPicks = picksByTeam.get(team.id) ?? [];
-              const isMyTeam = team.id === myTeamId;
 
               return (
                 <div
@@ -210,8 +219,9 @@ export default function DraftRoomBoard({
                       const pick = teamPicks.find((p) => p.slotIndex === slotIndex);
                       const player = pick ? playersById[pick.playerId] : null;
 
-                      // 자기 팀 슬롯만 DnD 활성.
-                      const hovered = hoverTarget?.index === slotIndex;
+                      // DnD 는 모든 팀에서 활성. 단, 출발-목적 팀이 같아야 drop 허용.
+                      const hovered =
+                        hoverTarget?.teamId === team.id && hoverTarget?.index === slotIndex;
                       const hoverOk = hovered && hoverTarget?.ok === true;
                       const hoverBad = hovered && hoverTarget?.ok === false;
                       const hoverRingClass = hoverOk
@@ -220,64 +230,74 @@ export default function DraftRoomBoard({
                         ? "ring-2 ring-rose-400/60"
                         : "";
 
-                      const dndProps = isMyTeam
-                        ? {
-                            onDragOver: (e: React.DragEvent) => {
-                              if (draggingFrom === null) return;
-                              e.preventDefault();
-                              e.dataTransfer.dropEffect = "move";
-                              const ok = isHoverEligible(slotIndex);
-                              if (hoverTarget?.index !== slotIndex || hoverTarget?.ok !== ok) {
-                                setHoverTarget({ index: slotIndex, ok });
-                              }
-                            },
-                            onDragLeave: () => {
-                              if (hoverTarget?.index === slotIndex) {
-                                setHoverTarget(null);
-                              }
-                            },
-                            onDrop: (e: React.DragEvent) => {
-                              e.preventDefault();
-                              const raw = e.dataTransfer.getData(DRAG_MIME);
-                              setHoverTarget(null);
-                              setDraggingFrom(null);
-                              if (!raw) return;
-                              const fromIndex = Number(raw);
-                              if (Number.isFinite(fromIndex)) {
-                                onSlotReassign?.(fromIndex, slotIndex, view);
-                              }
-                            },
+                      const dndProps = {
+                        onDragOver: (e: React.DragEvent) => {
+                          if (draggingFrom === null) return;
+                          // 다른 팀에서 출발한 드래그는 받지 않음 — preventDefault 안 하면 "no-drop" 커서.
+                          if (draggingFrom.teamId !== team.id) return;
+                          e.preventDefault();
+                          e.dataTransfer.dropEffect = "move";
+                          const ok = isHoverEligible(team.id, slotIndex);
+                          if (
+                            hoverTarget?.teamId !== team.id ||
+                            hoverTarget?.index !== slotIndex ||
+                            hoverTarget?.ok !== ok
+                          ) {
+                            setHoverTarget({ teamId: team.id, index: slotIndex, ok });
                           }
-                        : {};
+                        },
+                        onDragLeave: () => {
+                          if (
+                            hoverTarget?.teamId === team.id &&
+                            hoverTarget?.index === slotIndex
+                          ) {
+                            setHoverTarget(null);
+                          }
+                        },
+                        onDrop: (e: React.DragEvent) => {
+                          e.preventDefault();
+                          const raw = e.dataTransfer.getData(DRAG_MIME);
+                          setHoverTarget(null);
+                          setDraggingFrom(null);
+                          if (!raw) return;
+                          try {
+                            const parsed = JSON.parse(raw) as {
+                              teamId?: unknown;
+                              slotIndex?: unknown;
+                            };
+                            if (parsed.teamId !== team.id) return;
+                            if (typeof parsed.slotIndex !== "number") return;
+                            if (!Number.isFinite(parsed.slotIndex)) return;
+                            onSlotReassign?.(parsed.slotIndex, slotIndex, view, team.id);
+                          } catch {
+                            // ignore malformed payload
+                          }
+                        },
+                      };
 
                       if (pick && player) {
                         return (
                           <div
                             key={`${team.id}-${slotIndex}`}
-                            draggable={isMyTeam}
-                            onDragStart={
-                              isMyTeam
-                                ? (e: React.DragEvent) => {
-                                    e.dataTransfer.setData(DRAG_MIME, String(slotIndex));
-                                    e.dataTransfer.effectAllowed = "move";
-                                    setDraggingFrom(slotIndex);
-                                  }
-                                : undefined
-                            }
-                            onDragEnd={
-                              isMyTeam
-                                ? () => {
-                                    setDraggingFrom(null);
-                                    setHoverTarget(null);
-                                  }
-                                : undefined
-                            }
+                            draggable
+                            onDragStart={(e: React.DragEvent) => {
+                              e.dataTransfer.setData(
+                                DRAG_MIME,
+                                JSON.stringify({ teamId: team.id, slotIndex }),
+                              );
+                              e.dataTransfer.effectAllowed = "move";
+                              setDraggingFrom({ teamId: team.id, index: slotIndex });
+                            }}
+                            onDragEnd={() => {
+                              setDraggingFrom(null);
+                              setHoverTarget(null);
+                            }}
                             {...dndProps}
                             className={[
                               // 픽 카드 색은 픽을 가진 팀의 accent 로 통일 — 내 팀(sky) / 각 opponent 의 고유 색.
                               "relative rounded-xl border px-3 py-2 text-left transition",
                               accent.slot,
-                              isMyTeam ? "cursor-grab active:cursor-grabbing" : "",
+                              "cursor-grab active:cursor-grabbing",
                               hoverRingClass,
                             ].join(" ")}
                           >

--- a/fe/src/features/draft/statColumns.ts
+++ b/fe/src/features/draft/statColumns.ts
@@ -1,0 +1,63 @@
+// Stat-column registry for the draft page player list.
+//
+// Each stat has a key (used as the localStorage value and lookup id),
+// a display label, a group (batter / pitcher), an accessor that reads
+// the value from a player object, and a formatter that renders it.
+//
+// As the backend grows to expose more stat columns, append to STAT_DEFS;
+// no other code in this directory needs to change.
+
+import type { DraftPlayerPublic } from "../../types/draft";
+import { formatAvg } from "./utils";
+
+export type StatGroup = "batter" | "pitcher";
+
+export type StatDef = {
+  key: string;
+  label: string;
+  group: StatGroup;
+  accessor: (p: DraftPlayerPublic) => number | null | undefined;
+  format: (v: number | null | undefined) => string;
+};
+
+const formatInt = (v: number | null | undefined): string =>
+  v === null || v === undefined ? "—" : String(v);
+
+const formatDecimal = (digits: number) => (v: number | null | undefined): string =>
+  v === null || v === undefined ? "—" : v.toFixed(digits);
+
+export const STAT_DEFS: readonly StatDef[] = [
+  // Batter — keys currently exposed by the backend
+  { key: "AVG", label: "AVG", group: "batter", accessor: (p) => p.avg, format: (v) => (v == null ? "—" : formatAvg(v)) },
+  { key: "HR",  label: "HR",  group: "batter", accessor: (p) => p.hr,  format: formatInt },
+  { key: "RBI", label: "RBI", group: "batter", accessor: (p) => p.rbi, format: formatInt },
+  { key: "SB",  label: "SB",  group: "batter", accessor: (p) => p.sb,  format: formatInt },
+  { key: "AB",  label: "AB",  group: "batter", accessor: (p) => p.ab,  format: formatInt },
+
+  // Pitcher — keys currently exposed by the backend
+  { key: "ERA",  label: "ERA",  group: "pitcher", accessor: (p) => p.era,  format: formatDecimal(2) },
+  { key: "SO",   label: "SO",   group: "pitcher", accessor: (p) => p.so,   format: formatInt },
+  { key: "W",    label: "W",    group: "pitcher", accessor: (p) => p.w,    format: formatInt },
+  { key: "SV",   label: "SV",   group: "pitcher", accessor: (p) => p.sv,   format: formatInt },
+  { key: "IP",   label: "IP",   group: "pitcher", accessor: (p) => p.ip,   format: formatDecimal(1) },
+  { key: "WHIP", label: "WHIP", group: "pitcher", accessor: (p) => p.whip, format: formatDecimal(2) },
+];
+
+export const BATTER_DEFAULT_KEYS: readonly string[] = ["AVG", "HR", "RBI", "SB", "AB"];
+export const PITCHER_DEFAULT_KEYS: readonly string[] = ["ERA", "SO", "W", "SV", "IP"];
+
+export const STAT_COLUMN_COUNT = 5;
+
+const STAT_BY_KEY: Map<string, StatDef> = new Map(STAT_DEFS.map((s) => [s.key, s]));
+
+export function getStatDef(key: string): StatDef | undefined {
+  return STAT_BY_KEY.get(key);
+}
+
+export function getStatsForGroup(group: StatGroup): readonly StatDef[] {
+  return STAT_DEFS.filter((s) => s.group === group);
+}
+
+export function getDefaultsForGroup(group: StatGroup): readonly string[] {
+  return group === "batter" ? BATTER_DEFAULT_KEYS : PITCHER_DEFAULT_KEYS;
+}

--- a/fe/src/features/draft/useStatColumns.ts
+++ b/fe/src/features/draft/useStatColumns.ts
@@ -1,0 +1,92 @@
+// Hook backing the user's per-group stat-column selection (5 keys each).
+// Values live in localStorage so the choice persists across reloads on
+// this device only — same scope as ppadun_unsaved_draft.
+//
+// Reads validate length and key membership; bad data falls back to
+// defaults rather than crashing the page.
+
+import { useCallback, useState } from "react";
+import {
+  BATTER_DEFAULT_KEYS,
+  PITCHER_DEFAULT_KEYS,
+  STAT_COLUMN_COUNT,
+  getStatDef,
+  getDefaultsForGroup,
+  type StatGroup,
+} from "./statColumns";
+
+const BATTER_KEY = "ppadun_batter_stat_columns";
+const PITCHER_KEY = "ppadun_pitcher_stat_columns";
+
+function storageKey(group: StatGroup): string {
+  return group === "batter" ? BATTER_KEY : PITCHER_KEY;
+}
+
+function readCols(group: StatGroup): string[] {
+  const defaults = getDefaultsForGroup(group);
+  try {
+    const raw = localStorage.getItem(storageKey(group));
+    if (!raw) return [...defaults];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [...defaults];
+    if (parsed.length !== STAT_COLUMN_COUNT) return [...defaults];
+    // Every entry must be a known key in the matching group; otherwise
+    // the data is stale (e.g. backend renamed a column) and we reset.
+    for (const k of parsed) {
+      if (typeof k !== "string") return [...defaults];
+      const def = getStatDef(k);
+      if (!def || def.group !== group) return [...defaults];
+    }
+    return parsed as string[];
+  } catch {
+    return [...defaults];
+  }
+}
+
+function writeCols(group: StatGroup, cols: string[]): void {
+  try {
+    localStorage.setItem(storageKey(group), JSON.stringify(cols));
+  } catch {
+    // ignore — quota / privacy mode etc. The in-memory state still wins
+    // for the rest of the session.
+  }
+}
+
+export type UseStatColumns = {
+  batterCols: string[];
+  pitcherCols: string[];
+  setBatterCols: (cols: string[]) => void;
+  setPitcherCols: (cols: string[]) => void;
+  resetToDefaults: (group: StatGroup) => void;
+};
+
+export function useStatColumns(): UseStatColumns {
+  const [batterCols, setBatterColsState] = useState<string[]>(() => readCols("batter"));
+  const [pitcherCols, setPitcherColsState] = useState<string[]>(() => readCols("pitcher"));
+
+  const setBatterCols = useCallback((cols: string[]) => {
+    if (cols.length !== STAT_COLUMN_COUNT) return;
+    writeCols("batter", cols);
+    setBatterColsState(cols);
+  }, []);
+
+  const setPitcherCols = useCallback((cols: string[]) => {
+    if (cols.length !== STAT_COLUMN_COUNT) return;
+    writeCols("pitcher", cols);
+    setPitcherColsState(cols);
+  }, []);
+
+  const resetToDefaults = useCallback((group: StatGroup) => {
+    if (group === "batter") {
+      const next = [...BATTER_DEFAULT_KEYS];
+      writeCols("batter", next);
+      setBatterColsState(next);
+    } else {
+      const next = [...PITCHER_DEFAULT_KEYS];
+      writeCols("pitcher", next);
+      setPitcherColsState(next);
+    }
+  }, []);
+
+  return { batterCols, pitcherCols, setBatterCols, setPitcherCols, resetToDefaults };
+}

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -61,6 +61,9 @@ import AddBidModal from "../features/draft/components/AddBidModal";
 import TakenBidModal from "../features/draft/components/TakenBidModal";
 import PlayerComparisonModal from "../features/draft/components/PlayerComparisonModal";
 import PlayerNotePopover from "../features/draft/components/PlayerNotePopover";
+import CustomizeStatsModal from "../features/draft/components/CustomizeStatsModal";
+import { useStatColumns } from "../features/draft/useStatColumns";
+import { getStatDef } from "../features/draft/statColumns";
 import { useNotificationPolling } from "../hooks/useNotificationPolling";
 import type { NotificationEvent } from "../types/notifications";
 import PlayerInfoModal from "../features/players/components/PlayerInfoModal";
@@ -310,9 +313,12 @@ export default function DraftPage() {
   const positionFilters = DEFAULT_POSITION_FILTERS;
   const showingPitcherColumns = isPitcherPositionFilter(position);
   const sortOptions = showingPitcherColumns ? PITCHER_SORT_OPTIONS : BATTER_SORT_OPTIONS;
-  const statColumnLabels = showingPitcherColumns
-    ? ["ERA", "SO", "W", "SV", "IP"]
-    : ["AVG", "HR", "RBI", "SB", "AB"];
+
+  // 사용자가 선택한 5개 스탯 (타자/투수 별도) — localStorage에 영구 저장.
+  const { batterCols, pitcherCols, setBatterCols, setPitcherCols } = useStatColumns();
+  const [customizeStatsOpen, setCustomizeStatsOpen] = useState(false);
+  const activeStatKeys = showingPitcherColumns ? pitcherCols : batterCols;
+  const statColumnLabels = activeStatKeys.map((k) => getStatDef(k)?.label ?? k);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -823,17 +829,21 @@ export default function DraftPage() {
   //   - 메인: 자격(isEligibleForSlot) 검사 후 이동/스왑.
   //   - 마이너/택시: 포지션 자격이 없으니 순수 재정렬(스왑/빈자리 이동).
   // kind 는 어느 보드의 슬롯을 만지는지 — 같은 kind 내에서만 인덱스 충돌이 발생.
-  const handleSlotReassign = (fromIndex: number, toIndex: number, kind: DraftPickKind) => {
+  // teamId 는 재배치가 일어난 팀 — 내 팀뿐 아니라 opponent 팀의 픽도 사용자가 직접 정리 가능.
+  const handleSlotReassign = (
+    fromIndex: number,
+    toIndex: number,
+    kind: DraftPickKind,
+    teamId: string,
+  ) => {
     if (fromIndex === toIndex) return;
-    const myTeamId = myTeam?.id;
-    if (!myTeamId) return;
 
-    const myPicks = picks.filter(
-      (p) => p.draftedByTeamId === myTeamId && p.kind === kind
+    const teamPicks = picks.filter(
+      (p) => p.draftedByTeamId === teamId && p.kind === kind
     );
-    const fromPick = myPicks.find((p) => p.slotIndex === fromIndex);
+    const fromPick = teamPicks.find((p) => p.slotIndex === fromIndex);
     if (!fromPick) return;
-    const toPick = myPicks.find((p) => p.slotIndex === toIndex);
+    const toPick = teamPicks.find((p) => p.slotIndex === toIndex);
 
     // 마이너/택시: 자격 검사 없이 그냥 스왑/이동.
     if (kind !== "main") {
@@ -1234,7 +1244,6 @@ export default function DraftPage() {
               currentRound={currentRound}
               totalRounds={rosterSize}
               authed={authed}
-              myTeamId={myTeam?.id ?? null}
               view={boardView}
               onViewChange={setBoardView}
               onRemovePick={handleRemovePick}
@@ -1318,6 +1327,15 @@ export default function DraftPage() {
                 Remaining Budget: ${remainingBudget}
               </div>
             )}
+
+            <button
+              type="button"
+              onClick={() => setCustomizeStatsOpen(true)}
+              className="ml-auto rounded-full border border-white/20 bg-white px-3 py-1 text-xs font-extrabold text-zinc-900 transition hover:bg-zinc-100"
+              title="Pick which 5 stats appear in the table"
+            >
+              Customize Stats
+            </button>
           </div>
         </section>
       </FadeIn>
@@ -1547,21 +1565,21 @@ export default function DraftPage() {
                       </span>
                     </div>
 
-                    <div className="text-center text-white/70">
-                      {isPitcherOnly(player) ? formatNumber(player.era, 2) : formatAvg(player.avg)}
-                    </div>
-                    <div className="text-center font-semibold text-amber-300">
-                      {isPitcherOnly(player) ? player.so ?? "-" : player.hr ?? "-"}
-                    </div>
-                    <div className="text-center text-white/70">
-                      {isPitcherOnly(player) ? player.w ?? "-" : player.rbi ?? "-"}
-                    </div>
-                    <div className="text-center font-semibold text-amber-300">
-                      {isPitcherOnly(player) ? player.sv ?? "-" : player.sb ?? "-"}
-                    </div>
-                    <div className="text-center text-white/70">
-                      {isPitcherOnly(player) ? formatNumber(player.ip, 1) : player.ab ?? "-"}
-                    </div>
+                    {(isPitcherOnly(player) ? pitcherCols : batterCols).map((key, colIdx) => {
+                      const def = getStatDef(key);
+                      const value = def ? def.accessor(player) : null;
+                      const display = def ? def.format(value) : "—";
+                      // 짝수 컬럼은 옅은 화이트, 홀수 컬럼은 앰버 강조 — 시선 흐름 유지.
+                      const cellClass =
+                        colIdx % 2 === 0
+                          ? "text-center text-white/70"
+                          : "text-center font-semibold text-amber-300";
+                      return (
+                        <div key={key} className={cellClass}>
+                          {display}
+                        </div>
+                      );
+                    })}
 
                     <div className={`text-center font-black ${ppaValueClass(player.ppaValue, { authed })}`}>
                       {formatPpa(player.ppaValue)}
@@ -1672,6 +1690,18 @@ export default function DraftPage() {
         playerType={profilePlayerType}
         onClose={closePlayerInfo}
       />
+
+      {customizeStatsOpen && (
+        <CustomizeStatsModal
+          onClose={() => setCustomizeStatsOpen(false)}
+          batterCols={batterCols}
+          pitcherCols={pitcherCols}
+          onSave={(group, cols) => {
+            if (group === "batter") setBatterCols(cols);
+            else setPitcherCols(cols);
+          }}
+        />
+      )}
 
       {noteTarget && (
         <PlayerNotePopover


### PR DESCRIPTION

## What
<!-- What did you do? -->
- Customize Stats modal: pick 5 stats per group (batter / pitcher), drag to reorder, saved in localStorage
- Drag-and-drop slot reassignment now works on **every team's roster** (cross-team drops rejected)
- White trigger button under Sort; `Modal` gains optional `size="large"`

## Why
<!-- Why did you do it? -->
- Hardcoded stat columns can't accommodate the upcoming 15-stat backend rollout
- Recording opponent drafts was clunky — DnD should apply to every roster, not just mine
- 
## Related Issue
<!-- e.g. #123 -->
#102 