### PR TITLE
expand stat picker to full backend column set + fetch PPA on login

### DIFF
--- a/fe/src/features/draft/statColumns.ts
+++ b/fe/src/features/draft/statColumns.ts
@@ -4,8 +4,11 @@
 // a display label, a group (batter / pitcher), an accessor that reads
 // the value from a player object, and a formatter that renders it.
 //
-// As the backend grows to expose more stat columns, append to STAT_DEFS;
-// no other code in this directory needs to change.
+// Some field names (h / r / hr / bb) appear in both batter and pitcher
+// stat lists but mean different things (e.g. HR = home runs hit vs
+// home runs allowed). To keep the registry's key→def lookup unique,
+// the pitcher versions get a `P_` key prefix internally while the
+// user-facing label stays "H" / "R" / "HR" / "BB".
 
 import type { DraftPlayerPublic } from "../../types/draft";
 import { formatAvg } from "./utils";
@@ -26,21 +29,55 @@ const formatInt = (v: number | null | undefined): string =>
 const formatDecimal = (digits: number) => (v: number | null | undefined): string =>
   v === null || v === undefined ? "—" : v.toFixed(digits);
 
-export const STAT_DEFS: readonly StatDef[] = [
-  // Batter — keys currently exposed by the backend
-  { key: "AVG", label: "AVG", group: "batter", accessor: (p) => p.avg, format: (v) => (v == null ? "—" : formatAvg(v)) },
-  { key: "HR",  label: "HR",  group: "batter", accessor: (p) => p.hr,  format: formatInt },
-  { key: "RBI", label: "RBI", group: "batter", accessor: (p) => p.rbi, format: formatInt },
-  { key: "SB",  label: "SB",  group: "batter", accessor: (p) => p.sb,  format: formatInt },
-  { key: "AB",  label: "AB",  group: "batter", accessor: (p) => p.ab,  format: formatInt },
+// AVG-style: strip leading 0 → ".280"
+const formatRate3 = (v: number | null | undefined): string =>
+  v === null || v === undefined ? "—" : formatAvg(v);
 
-  // Pitcher — keys currently exposed by the backend
-  { key: "ERA",  label: "ERA",  group: "pitcher", accessor: (p) => p.era,  format: formatDecimal(2) },
-  { key: "SO",   label: "SO",   group: "pitcher", accessor: (p) => p.so,   format: formatInt },
-  { key: "W",    label: "W",    group: "pitcher", accessor: (p) => p.w,    format: formatInt },
-  { key: "SV",   label: "SV",   group: "pitcher", accessor: (p) => p.sv,   format: formatInt },
-  { key: "IP",   label: "IP",   group: "pitcher", accessor: (p) => p.ip,   format: formatDecimal(1) },
-  { key: "WHIP", label: "WHIP", group: "pitcher", accessor: (p) => p.whip, format: formatDecimal(2) },
+export const STAT_DEFS: readonly StatDef[] = [
+  // ── Batter (15) ────────────────────────────────────────────────────
+  { key: "AB",  label: "AB",  group: "batter", accessor: (p) => p.ab,     format: formatInt },
+  { key: "R",   label: "R",   group: "batter", accessor: (p) => p.r,      format: formatInt },
+  { key: "H",   label: "H",   group: "batter", accessor: (p) => p.h,      format: formatInt },
+  { key: "1B",  label: "1B",  group: "batter", accessor: (p) => p.single, format: formatInt },
+  { key: "2B",  label: "2B",  group: "batter", accessor: (p) => p.double, format: formatInt },
+  { key: "3B",  label: "3B",  group: "batter", accessor: (p) => p.triple, format: formatInt },
+  { key: "HR",  label: "HR",  group: "batter", accessor: (p) => p.hr,     format: formatInt },
+  { key: "RBI", label: "RBI", group: "batter", accessor: (p) => p.rbi,    format: formatInt },
+  { key: "BB",  label: "BB",  group: "batter", accessor: (p) => p.bb,     format: formatInt },
+  { key: "K",   label: "K",   group: "batter", accessor: (p) => p.k,      format: formatInt },
+  { key: "SB",  label: "SB",  group: "batter", accessor: (p) => p.sb,     format: formatInt },
+  { key: "CS",  label: "CS",  group: "batter", accessor: (p) => p.cs,     format: formatInt },
+  { key: "AVG", label: "AVG", group: "batter", accessor: (p) => p.avg,    format: formatRate3 },
+  { key: "OBP", label: "OBP", group: "batter", accessor: (p) => p.obp,    format: formatRate3 },
+  { key: "SLG", label: "SLG", group: "batter", accessor: (p) => p.slg,    format: formatRate3 },
+
+  // ── Pitcher (24) ───────────────────────────────────────────────────
+  { key: "W",        label: "W",     group: "pitcher", accessor: (p) => p.w,        format: formatInt },
+  { key: "L",        label: "L",     group: "pitcher", accessor: (p) => p.l,        format: formatInt },
+  { key: "SV",       label: "SV",    group: "pitcher", accessor: (p) => p.sv,       format: formatInt },
+  { key: "SO",       label: "SO",    group: "pitcher", accessor: (p) => p.so,       format: formatInt },
+  { key: "ERA",      label: "ERA",   group: "pitcher", accessor: (p) => p.era,      format: formatDecimal(2) },
+  { key: "WHIP",     label: "WHIP",  group: "pitcher", accessor: (p) => p.whip,     format: formatDecimal(2) },
+  { key: "IP",       label: "IP",    group: "pitcher", accessor: (p) => p.ip,       format: formatDecimal(1) },
+  { key: "G",        label: "G",     group: "pitcher", accessor: (p) => p.g,        format: formatInt },
+  { key: "GS",       label: "GS",    group: "pitcher", accessor: (p) => p.gs,       format: formatInt },
+  { key: "WAR",      label: "WAR",   group: "pitcher", accessor: (p) => p.war,      format: formatDecimal(1) },
+  { key: "FIP",      label: "FIP",   group: "pitcher", accessor: (p) => p.fip,      format: formatDecimal(2) },
+  // 4 overlapping field names — internal key prefixed to stay unique,
+  // user-facing label stays as the simple stat abbreviation.
+  { key: "P_H",      label: "H",     group: "pitcher", accessor: (p) => p.h,        format: formatInt },
+  { key: "P_R",      label: "R",     group: "pitcher", accessor: (p) => p.r,        format: formatInt },
+  { key: "ER",       label: "ER",    group: "pitcher", accessor: (p) => p.er,       format: formatInt },
+  { key: "P_HR",     label: "HR",    group: "pitcher", accessor: (p) => p.hr,       format: formatInt },
+  { key: "P_BB",     label: "BB",    group: "pitcher", accessor: (p) => p.bb,       format: formatInt },
+  { key: "HBP",      label: "HBP",   group: "pitcher", accessor: (p) => p.hbp,      format: formatInt },
+  { key: "BF",       label: "BF",    group: "pitcher", accessor: (p) => p.bf,       format: formatInt },
+  { key: "ERA_PLUS", label: "ERA+",  group: "pitcher", accessor: (p) => p.era_plus, format: formatInt },
+  { key: "H9",       label: "H/9",   group: "pitcher", accessor: (p) => p.h9,       format: formatDecimal(2) },
+  { key: "HR9",      label: "HR/9",  group: "pitcher", accessor: (p) => p.hr9,      format: formatDecimal(2) },
+  { key: "BB9",      label: "BB/9",  group: "pitcher", accessor: (p) => p.bb9,      format: formatDecimal(2) },
+  { key: "SO9",      label: "SO/9",  group: "pitcher", accessor: (p) => p.so9,      format: formatDecimal(2) },
+  { key: "SO_BB",    label: "SO/BB", group: "pitcher", accessor: (p) => p.so_bb,    format: formatDecimal(2) },
 ];
 
 export const BATTER_DEFAULT_KEYS: readonly string[] = ["AVG", "HR", "RBI", "SB", "AB"];

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -754,8 +754,11 @@ export default function DraftPage() {
   // 인증된 사용자에게만 PPA 값 + 추천 bid 를 불러와 playerId 로 공개 목록과 머지한다.
   // 로그아웃 시 값을 즉시 지워서 UI 에 남지 않도록 함.
   // picks/config 가 바뀔 때마다 재호출 — 잔여 예산 변동에 따라 백엔드의 추천 bid 가 갱신되기 때문.
+  // hasDraftConfig 는 의도적으로 의존하지 않음 — 로그인만 하면 (Start Draft 누르기 전에도)
+  // PPA 값이 보여야 한다. 드래프트 시작 전엔 config 가 DEFAULT_DRAFT_CONFIG 로 채워져 있어서
+  // 백엔드가 기본 예산/로스터/상대수로 추천 bid 를 계산해 돌려준다.
   useEffect(() => {
-    if (!authed || !config || !hasDraftConfig) {
+    if (!authed || !config) {
       queueMicrotask(() => setPlayerValues(null));
       return;
     }
@@ -779,7 +782,7 @@ export default function DraftPage() {
       });
 
     return () => controller.abort();
-  }, [authed, config, hasDraftConfig, picks]);
+  }, [authed, config, picks]);
 
   // Toggle player selection for A/B comparison (max 2 players).
   const handleCompareToggle = (playerId: string) => {

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -8,17 +8,45 @@ export type DraftPlayerPublic = {
   playerType: "batter" | "pitcher" | "two_way";
   team: string;                  // MLB 팀 약어 (예: "NYY")
   positions: string[];           // 포지션 배열 (예: ["OF", "DH"])
-  avg: number | null;            // 타율
-  hr: number | null;             // 홈런
+
+  // ── 타자 스탯 ────────────────────────────────────────────────────────
+  ab: number | null;             // 타수
+  r: number | null;              // 득점 (타자) / 실점 (투수)
+  h: number | null;              // 안타 (타자) / 피안타 (투수)
+  single: number | null;         // 1루타
+  double: number | null;         // 2루타
+  triple: number | null;         // 3루타
+  hr: number | null;             // 홈런 (타자) / 피홈런 (투수)
   rbi: number | null;            // 타점
+  bb: number | null;             // 볼넷 (타자) / 볼넷 허용 (투수)
+  k: number | null;              // 삼진
   sb: number | null;             // 도루
-  ab: number | null;             // 타석
-  w: number | null;
-  sv: number | null;
-  so: number | null;
-  era: number | null;
-  whip: number | null;
-  ip: number | null;
+  cs: number | null;             // 도루 실패
+  avg: number | null;            // 타율
+  obp: number | null;            // 출루율
+  slg: number | null;            // 장타율
+
+  // ── 투수 스탯 (h, r, hr, bb 는 위와 공유 — 문맥에 따라 의미가 달라짐) ──
+  w: number | null;              // 승
+  l: number | null;              // 패
+  sv: number | null;             // 세이브
+  so: number | null;             // 탈삼진
+  era: number | null;            // 평균자책점
+  whip: number | null;           // WHIP
+  ip: number | null;             // 이닝 (소수점은 1/3 단위 표기 — 184.2 = 184 2/3)
+  g: number | null;              // 등판
+  gs: number | null;             // 선발 등판
+  war: number | null;            // WAR
+  fip: number | null;            // FIP
+  er: number | null;             // 자책점
+  hbp: number | null;            // 사구
+  bf: number | null;             // 상대 타자 수
+  era_plus: number | null;       // 조정 ERA (ERA+)
+  h9: number | null;             // 9이닝당 피안타
+  hr9: number | null;             // 9이닝당 피홈런
+  bb9: number | null;             // 9이닝당 볼넷
+  so9: number | null;             // 9이닝당 탈삼진
+  so_bb: number | null;           // K/BB 비율
 };
 
 /**


### PR DESCRIPTION

## What
<!-- What did you do? -->
- `DraftPlayerPublic` now types every field the backend sends (35 unique)
- `STAT_DEFS` expanded to 15 batter + 24 pitcher entries; users can pick any 5 per group
- 4 overlapping fields (h/r/hr/bb) get internal `P_` key prefix; user-facing labels stay simple
- PPA values + recommended bids fetch as soon as a user logs in — no need to click Start Draft

## Why
<!-- Why did you do it? -->
- Backend already exposes the full column set; FE was only mapping 5/6
- "Start Draft" gate hid PPA values from users just browsing — they should see scores on entry


## Related Issue
<!-- e.g. #123 -->
#102 