### PR TITLE
chore: refresh home page news every 10 minutes

### DIFF
--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -66,7 +66,7 @@ export default function HomePage() {
     };
 
     fetchNews();
-    const interval = setInterval(fetchNews, 60 * 60 * 1000); // 1시간마다
+    const interval = setInterval(fetchNews, 10 * 60 * 1000); // 10분마다
     return () => clearInterval(interval);
   }, []);
 


### PR DESCRIPTION
## What
<!-- What did you do? -->
- \`fe/src/pages/HomePage.tsx\`: news fetch interval changed from \`60 * 60 * 1000\` (1 hour) to \`10 * 60 * 1000\` (10 min)
- Updated the trailing comment to match

## Why
<!-- Why did you do it? -->
- 1-hour cadence made the news cards feel stale
- rss2json free tier is per-IP (each user's browser hits it independently), so 10-min polling is ~0.5% of the daily limit — zero cost concern

## Related Issue
<!-- e.g. #123 -->
- Closes #107