### PR TITLE
split P filter into SP/RP and make UTIL position-exact

### DIFF
--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -84,13 +84,14 @@ const DEFAULT_POSITION_FILTERS: DraftPositionFilter[] = [
   "SS",
   "OF",
   "UTIL",
-  "P",
+  "SP",
+  "RP",
 ];
 
 // Match a player against a position filter.
-// - UTIL  : any non-pitcher position (1B/2B/3B/SS/OF/C/UTIL all qualify)
-// - P     : any pitcher position (SP or RP)
-// - other : exact match (case-insensitive, defensive against empty arrays)
+// 모든 필터는 정확한 포지션 일치 — UTIL 칩은 "UTIL 자격이 있는 선수"만 골라낸다.
+// (예전엔 UTIL 이 "투수가 아닌 모든 선수"였는데, 그건 사실상 "전체 타자" 필터라
+//  포지션 칩의 의미와 맞지 않아 정확 일치로 바꿈.)
 function matchesPositionFilter(
   playerPositions: readonly string[] | undefined,
   filter: DraftPositionFilter
@@ -98,13 +99,6 @@ function matchesPositionFilter(
   if (!playerPositions || playerPositions.length === 0) return false;
 
   const normalized = playerPositions.map((p) => p.toUpperCase());
-
-  if (filter === "UTIL") {
-    return normalized.some((p) => p !== "SP" && p !== "RP");
-  }
-  if (filter === "P") {
-    return normalized.some((p) => p === "SP" || p === "RP");
-  }
   return normalized.includes(filter);
 }
 
@@ -113,7 +107,7 @@ function isPitcherOnly(player: DraftPlayerPublic): boolean {
 }
 
 function isPitcherPositionFilter(filter: DraftPositionFilter): boolean {
-  return filter === "P" || filter === "SP" || filter === "RP";
+  return filter === "SP" || filter === "RP";
 }
 
 function formatNumber(value: number | null | undefined, digits: number) {

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -193,9 +193,9 @@ export type DraftSort =
  * DraftPositionFilter: 포지션 필터 옵션
  * - "ALL" 은 의도적으로 제외 — 타자/투수 스탯이 분리되어 한 화면에 섞으면
  *   빈 컬럼이 생기기 때문 ("pick 5 stat columns" 기능 대비).
+ * - "P" 는 의도적으로 제외 — 투수는 SP / RP 로만 필터.
  */
 export type DraftPositionFilter =
-  | "P"        // 투수 전체 (SP + RP)
   | "SP"       // 선발 투수
   | "RP"       // 구원 투수
   | "C"        // 포수


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Replaced the single `P` chip with separate `SP` and `RP` chips so users
  can filter by pitcher role
- Fixed `UTIL` chip to match players whose position actually includes
  `UTIL`, instead of every non-pitcher
- Removed `"P"` from `DraftPositionFilter` type — only used in-memory, no
  migration needed

## Why
<!-- Why did you do it? -->
- `P` lumped starters and relievers together, hiding the role distinction
  drafters care about
- `UTIL` was effectively a "Batters" filter (showed every non-pitcher),
  which doesn't match what the chip label implies

## Related Issue
<!-- e.g. #123 -->
#110 