### PR TITLE
decompose DraftPage + add undo/redo keyboard shortcuts

### DIFF
--- a/fe/src/features/draft/components/ComparisonPanel.tsx
+++ b/fe/src/features/draft/components/ComparisonPanel.tsx
@@ -1,0 +1,113 @@
+// "Compare" toolbar — two emerald slots (A / B) plus Clear / Compare buttons.
+// Each slot shows the selected player's name, position, team, recommended bid,
+// and a one-line stat summary. Presentation only.
+
+import FadeIn from "../../../components/ui/FadeIn";
+import type { DraftPlayer } from "../../../types/draft";
+import { formatDraftStatSummary } from "../draftHelpers";
+
+type Props = {
+  selectedA: DraftPlayer | null;
+  selectedB: DraftPlayer | null;
+  authed: boolean;
+  onClearA: () => void;
+  onClearB: () => void;
+  onClearAll: () => void;
+  onOpenComparison: () => void;
+};
+
+type SlotProps = {
+  label: "A" | "B";
+  player: DraftPlayer | null;
+  onClear: () => void;
+};
+
+function CompareSlot({ label, player, onClear }: SlotProps) {
+  return (
+    <div className="min-w-0 w-full rounded-xl border border-emerald-400/50 bg-emerald-500/12 px-3 py-2 shadow-[0_0_16px_rgba(16,185,129,0.18)] sm:w-[300px]">
+      {player ? (
+        <>
+          <div className="flex items-center justify-between gap-2 text-xs text-white/80">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="rounded bg-emerald-500/25 px-1.5 py-0.5 font-black text-emerald-100">
+                {label}
+              </span>
+              <span className="truncate font-black text-white">{player.name}</span>
+            </div>
+            <button
+              type="button"
+              onClick={onClear}
+              className="grid h-5 w-5 place-items-center rounded-full border border-white/20 bg-black/20 text-[10px] font-black text-white/80 transition hover:bg-white/15"
+              aria-label={`Remove player ${label} from compare`}
+              title={`Remove player ${label}`}
+            >
+              X
+            </button>
+          </div>
+          <div className="mt-1 text-[11px] font-semibold text-white/70">
+            {player.positions.join("/")} - {player.team} - ${player.recommendedBid ?? "—"}
+          </div>
+          <div className="mt-1 text-[10px] text-white/55">
+            {formatDraftStatSummary(player)}
+          </div>
+        </>
+      ) : (
+        <div className="text-xs font-bold text-white/55">Select player {label}</div>
+      )}
+    </div>
+  );
+}
+
+export default function ComparisonPanel({
+  selectedA,
+  selectedB,
+  authed,
+  onClearA,
+  onClearB,
+  onClearAll,
+  onOpenComparison,
+}: Props) {
+  const bothSelected = Boolean(selectedA && selectedB);
+  const noneSelected = !selectedA && !selectedB;
+
+  return (
+    <FadeIn delayMs={120}>
+      <section className="rounded-2xl border border-fuchsia-500/55 bg-[#1b1228] p-4 shadow-[0_0_22px_rgba(168,85,247,0.22)]">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex min-w-0 flex-1 flex-col gap-3 lg:flex-row lg:items-center">
+            <div className="rounded-xl bg-fuchsia-500/15 px-4 py-3 ring-1 ring-fuchsia-300/40 lg:min-w-[170px]">
+              <div className="text-sm font-black text-fuchsia-200">Compare</div>
+              <div className="mt-0.5 text-[11px] font-bold text-white/65">Select 2 players</div>
+            </div>
+
+            <div className="flex min-w-0 flex-1 flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-center">
+              <CompareSlot label="A" player={selectedA} onClear={onClearA} />
+              <div className="text-center text-xs font-black text-fuchsia-200 sm:px-1">VS</div>
+              <CompareSlot label="B" player={selectedB} onClear={onClearB} />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 self-end lg:self-auto">
+            <button
+              type="button"
+              onClick={onClearAll}
+              disabled={noneSelected}
+              className="rounded-xl border border-white/15 bg-black/25 px-4 py-2 text-xs font-black text-white/80 transition hover:bg-white/10 disabled:opacity-40"
+            >
+              Clear
+            </button>
+            <button
+              type="button"
+              onClick={onOpenComparison}
+              disabled={!bothSelected || !authed}
+              className="rounded-xl bg-fuchsia-600 px-4 py-2 text-xs font-black text-white transition hover:bg-fuchsia-500 disabled:opacity-40"
+              title={!authed ? "Sign in required" : "Open player comparison"}
+            >
+              Compare
+            </button>
+          </div>
+        </div>
+      </section>
+    </FadeIn>
+  );
+}

--- a/fe/src/features/draft/components/DraftHeaderBar.tsx
+++ b/fe/src/features/draft/components/DraftHeaderBar.tsx
@@ -1,0 +1,138 @@
+// Header bar across the top of the draft page — title + subtitle,
+// undo/redo/discard/save/import buttons, and the remaining-budget chip.
+// Presentation only: every action is a callback, every value a prop.
+
+import FadeIn from "../../../components/ui/FadeIn";
+import type { DraftConfigServer } from "../../../types/draft";
+
+type Props = {
+  sessionName: string | null;
+  config: DraftConfigServer | null;
+  hasDraftConfig: boolean;
+  isLoadedMode: boolean;
+  rosterSize: number;
+  remainingBudget: number;
+  authed: boolean;
+  canUndoPicks: boolean;
+  canRedoPicks: boolean;
+  onUndo: () => void;
+  onRedo: () => void;
+  onDiscard: () => void;
+  onSave: () => void;
+  onImport: () => void;
+};
+
+export default function DraftHeaderBar({
+  sessionName,
+  config,
+  hasDraftConfig,
+  isLoadedMode,
+  rosterSize,
+  remainingBudget,
+  authed,
+  canUndoPicks,
+  canRedoPicks,
+  onUndo,
+  onRedo,
+  onDiscard,
+  onSave,
+  onImport,
+}: Props) {
+  return (
+    <FadeIn>
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <div className="text-sm font-black text-white/70">PPA-DUN</div>
+          <h1 className="mt-1 text-3xl font-black text-white">
+            {sessionName ?? "Draft Room"}
+          </h1>
+          {hasDraftConfig && config ? (
+            <p className="mt-2 text-sm text-white/60">
+              {String(config.leagueType ?? "AL").toUpperCase()} - ${config.budget} Budget - {rosterSize} Players
+            </p>
+          ) : (
+            <p className="mt-2 text-sm text-white/60">
+              Browse players without starting a draft.
+            </p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {hasDraftConfig && (
+            <>
+              <button
+                type="button"
+                onClick={onUndo}
+                disabled={!canUndoPicks}
+                aria-label="Undo"
+                className="grid h-12 w-12 place-items-center rounded-2xl border border-white/15 bg-black/25 text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black/25"
+                title="Undo the last pick change"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+                  <path d="M9 14l-4-4 4-4" />
+                  <path d="M5 10h11a4 4 0 0 1 0 8h-2" />
+                </svg>
+              </button>
+              <button
+                type="button"
+                onClick={onRedo}
+                disabled={!canRedoPicks}
+                aria-label="Redo"
+                className="grid h-12 w-12 place-items-center rounded-2xl border border-white/15 bg-black/25 text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black/25"
+                title="Redo the last undone change"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+                  <path d="M15 14l4-4-4-4" />
+                  <path d="M19 10H8a4 4 0 0 0 0 8h2" />
+                </svg>
+              </button>
+            </>
+          )}
+          {hasDraftConfig && (
+            <button
+              type="button"
+              onClick={onDiscard}
+              className="rounded-2xl border border-rose-400/30 bg-rose-500/10 px-4 py-3 text-sm font-black text-rose-200 transition hover:bg-rose-500/20"
+              title={
+                isLoadedMode
+                  ? "Clear all picks of the current saved session"
+                  : "Discard the current unsaved draft and start over"
+              }
+            >
+              Discard
+            </button>
+          )}
+          {authed && (
+            <>
+              {hasDraftConfig && (
+                <button
+                  type="button"
+                  onClick={onSave}
+                  className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-3 text-sm font-black text-emerald-200 transition hover:bg-emerald-500/20"
+                  title="Save current draft as a session"
+                >
+                  Save
+                </button>
+              )}
+              <button
+                type="button"
+                onClick={onImport}
+                className="rounded-2xl border border-white/15 bg-black/25 px-4 py-3 text-sm font-black text-white/80 transition hover:bg-white/10"
+                title="Import a saved session"
+              >
+                Import
+              </button>
+            </>
+          )}
+
+          {hasDraftConfig && (
+            <div className="rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
+              <div className="text-xs font-extrabold text-white/60">Remaining Budget</div>
+              <div className="mt-1 text-2xl font-black text-emerald-400">${remainingBudget}</div>
+            </div>
+          )}
+        </div>
+      </div>
+    </FadeIn>
+  );
+}

--- a/fe/src/features/draft/components/ImportSessionsModal.tsx
+++ b/fe/src/features/draft/components/ImportSessionsModal.tsx
@@ -1,0 +1,83 @@
+// Import modal — lists saved sessions with delete buttons. Presentation
+// only: list data and handlers come from the parent (DraftPage). Rendered
+// conditionally by the parent so no `open` prop here.
+
+import type { SessionSummary } from "../../../types/draft";
+
+type Props = {
+  sessions: SessionSummary[];
+  loading: boolean;
+  onClose: () => void;
+  onPick: (id: number) => void;
+  onDelete: (id: number) => void;
+};
+
+export default function ImportSessionsModal({
+  sessions,
+  loading,
+  onClose,
+  onPick,
+  onDelete,
+}: Props) {
+  return (
+    <div className="fixed inset-0 z-[80] grid place-items-center p-4">
+      <button
+        type="button"
+        aria-label="Close import dialog"
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative w-full max-w-lg rounded-3xl border border-white/15 bg-[#0c1220] p-6 shadow-2xl">
+        <div className="flex items-center justify-between">
+          <div className="text-lg font-black text-white">Saved Sessions</div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="grid h-8 w-8 place-items-center rounded-full border border-white/15 bg-black/25 text-sm font-black text-white/80 hover:bg-white/10"
+            aria-label="Close"
+          >
+            X
+          </button>
+        </div>
+
+        <div className="mt-4 max-h-[60vh] overflow-y-auto rounded-2xl border border-white/10 bg-black/20">
+          {loading && (
+            <div className="p-4 text-sm text-white/65">Loading sessions...</div>
+          )}
+
+          {!loading && sessions.length === 0 && (
+            <div className="p-4 text-sm text-white/65">No saved sessions yet.</div>
+          )}
+
+          {!loading &&
+            sessions.map((s) => (
+              <div
+                key={s.id}
+                className="flex items-center gap-3 border-b border-white/5 px-4 py-3 last:border-b-0 hover:bg-white/5"
+              >
+                <button
+                  type="button"
+                  onClick={() => onPick(s.id)}
+                  className="flex-1 text-left"
+                >
+                  <div className="text-sm font-black text-white">{s.name}</div>
+                  <div className="mt-0.5 text-xs text-white/55">
+                    {s.createdAt.slice(0, 10)}
+                  </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onDelete(s.id)}
+                  aria-label="Delete session"
+                  title="Delete session"
+                  className="grid h-9 w-9 place-items-center rounded-xl border border-rose-400/30 bg-rose-500/10 text-rose-200 transition hover:bg-rose-500/20"
+                >
+                  🗑
+                </button>
+              </div>
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/draft/components/PlayerListTable.tsx
+++ b/fe/src/features/draft/components/PlayerListTable.tsx
@@ -1,0 +1,293 @@
+// Player list table — the main grid showing every available player with
+// stats, PPA value, Add / Taken buttons, and the compare toggle.
+//
+// Pure presentation: state and handlers live in DraftPage. Pagination is
+// included so the parent only needs to pass page / totalPages / setPage.
+
+import FadeIn from "../../../components/ui/FadeIn";
+import Skeleton from "../../../components/ui/Skeleton";
+import Pagination from "../../../features/players/components/Pagination";
+import { formatPpa, ppaValueClass } from "../../../utils/playerValue";
+import type {
+  DraftPick,
+  DraftPlayer,
+  DraftPlayerPublic,
+  DraftTeam,
+} from "../../../types/draft";
+import {
+  draftCostClass,
+  getPlayerDraftStatus,
+  mlbTeamBadgeClass,
+  teamAccentClass,
+} from "../utils";
+import { isPitcherOnly } from "../draftHelpers";
+import { getStatDef } from "../statColumns";
+
+type Props = {
+  players: DraftPlayer[];
+  picks: DraftPick[];
+  teams: DraftTeam[];
+  page: number;
+  pageSize: number;
+  totalPages: number;
+  onChangePage: (next: number) => void;
+  statColumnLabels: string[];
+  batterCols: string[];
+  pitcherCols: string[];
+  loading: boolean;
+  error: string | null;
+  authed: boolean;
+  notes: Record<string, string>;
+  affectedPlayerIds: Set<string>;
+  compareAId: string | null;
+  compareBId: string | null;
+  onAddPick: (player: DraftPlayerPublic) => void;
+  onTakenPick: (player: DraftPlayerPublic) => void;
+  onOpenNote: (player: DraftPlayerPublic) => void;
+  onOpenPlayerInfo: (id: string, type: DraftPlayerPublic["playerType"]) => void;
+  onToggleCompare: (id: string) => void;
+};
+
+export default function PlayerListTable({
+  players,
+  picks,
+  teams,
+  page,
+  pageSize,
+  totalPages,
+  onChangePage,
+  statColumnLabels,
+  batterCols,
+  pitcherCols,
+  loading,
+  error,
+  authed,
+  notes,
+  affectedPlayerIds,
+  compareAId,
+  compareBId,
+  onAddPick,
+  onTakenPick,
+  onOpenNote,
+  onOpenPlayerInfo,
+  onToggleCompare,
+}: Props) {
+  return (
+    <FadeIn delayMs={140}>
+      <section className="overflow-hidden rounded-3xl border border-white/10 bg-white/5">
+        <div className="grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_.9fr_1.3fr_1.1fr_.9fr] bg-black/40 px-4 py-3 text-xs font-extrabold text-white/60">
+          <div className="text-center">#</div>
+          <div>Player</div>
+          <div className="text-center">Pos</div>
+          <div className="text-center">Cost</div>
+          <div className="text-center">Team</div>
+          <div className="text-center">{statColumnLabels[0]}</div>
+          <div className="text-center">{statColumnLabels[1]}</div>
+          <div className="text-center">{statColumnLabels[2]}</div>
+          <div className="text-center">{statColumnLabels[3]}</div>
+          <div className="text-center">{statColumnLabels[4]}</div>
+          <div className="text-center">PPA-Value</div>
+          <div className="text-center">Action</div>
+          <div className="text-center">Compare</div>
+        </div>
+
+        <div className="bg-black/20">
+          {loading && (
+            <div className="p-4">
+              <Skeleton className="h-24" />
+            </div>
+          )}
+
+          {!loading && error && (
+            <div className="p-4 text-sm text-red-200">Failed to load players: {error}</div>
+          )}
+
+          {!loading && !error && players.length === 0 && (
+            <div className="p-4 text-sm text-white/70">No results. Try another search or filter.</div>
+          )}
+
+          {!loading &&
+            !error &&
+            players.map((player, idx) => {
+              const status = getPlayerDraftStatus(player.id, picks, teams);
+              // 픽된 경우 그 팀의 accent 컬러 — 뱃지를 팀별 색으로 통일.
+              const pickedByTeamIdx =
+                status.kind !== "available"
+                  ? teams.findIndex((t) => t.id === status.teamId)
+                  : -1;
+              const pickedAccent =
+                pickedByTeamIdx >= 0
+                  ? teamAccentClass(teams[pickedByTeamIdx], pickedByTeamIdx)
+                  : null;
+              const compareAActive = compareAId === player.id;
+              const compareBActive = compareBId === player.id;
+              const compareRole = compareAActive ? "A" : compareBActive ? "B" : null;
+              const compareActive = Boolean(compareRole);
+
+              return (
+                <div
+                  key={player.id}
+                  className={[
+                    "grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_.9fr_1.3fr_1.1fr_.9fr] items-center px-4 py-3 text-sm text-white/85 transition tabular-nums",
+                    compareActive
+                      ? "relative z-[1] my-1 rounded-xl border border-emerald-400/75 bg-emerald-500/10 shadow-[0_0_18px_rgba(16,185,129,0.35)]"
+                      : "hover:bg-white/5",
+                  ].join(" ")}
+                >
+                  <div className="text-center text-white/45">{(page - 1) * pageSize + idx + 1}</div>
+
+                  <div className="min-w-0 flex items-center gap-1">
+                    {affectedPlayerIds.has(player.id) && (
+                      <span
+                        className="inline-block h-2 w-2 shrink-0 rounded-full bg-rose-500 animate-pulse"
+                        title="Recent update"
+                        aria-label="Recent update"
+                      />
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => onOpenPlayerInfo(player.id, player.playerType)}
+                      className="block w-full truncate rounded-md border border-transparent px-2 py-1 -mx-2 -my-1 text-left font-semibold text-white transition hover:border-white/35 hover:bg-white/5 hover:text-amber-200 focus-visible:border-white/45 focus-visible:bg-white/10 focus-visible:outline-none"
+                      title={player.name}
+                    >
+                      {player.name}
+                    </button>
+                    <button
+                      type="button"
+                      disabled={!authed}
+                      onClick={() => onOpenNote(player)}
+                      aria-label={notes[player.id] ? "Edit note" : "Add note"}
+                      title={
+                        !authed
+                          ? "Sign in required"
+                          : notes[player.id]
+                          ? "Edit note"
+                          : "Add note"
+                      }
+                      className={[
+                        "grid h-7 w-7 place-items-center rounded-md border transition",
+                        notes[player.id]
+                          ? "border-amber-400/50 bg-amber-500/15 text-amber-300 hover:bg-amber-500/25"
+                          : "border-white/10 bg-white/5 text-white/55 hover:bg-white/10 hover:text-white/80",
+                        !authed && "cursor-not-allowed opacity-40 hover:bg-white/5",
+                      ]
+                        .filter(Boolean)
+                        .join(" ")}
+                    >
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
+                        <path d="M14 3v4a1 1 0 0 0 1 1h4" />
+                        <path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2Z" />
+                        <path d="M9 9h1" />
+                        <path d="M9 13h6" />
+                        <path d="M9 17h6" />
+                      </svg>
+                    </button>
+                  </div>
+
+                  <div className="text-center">
+                    <span className="inline-block rounded-lg bg-white/10 px-2 py-1 text-[11px] font-extrabold text-white/80">
+                      {player.positions[0]}
+                    </span>
+                  </div>
+
+                  <div className={`text-center ${draftCostClass(authed)}`}>${player.recommendedBid ?? "—"}</div>
+
+                  <div className="text-center">
+                    <span
+                      className={[
+                        "inline-flex items-center rounded-lg border px-2 py-1 text-[11px] font-extrabold",
+                        mlbTeamBadgeClass(player.team),
+                      ].join(" ")}
+                    >
+                      {player.team}
+                    </span>
+                  </div>
+
+                  {(isPitcherOnly(player) ? pitcherCols : batterCols).map((key, colIdx) => {
+                    const def = getStatDef(key);
+                    const value = def ? def.accessor(player) : null;
+                    const display = def ? def.format(value) : "—";
+                    // 짝수 컬럼 옅은 화이트, 홀수 컬럼 앰버 강조 — 시선 흐름.
+                    const cellClass =
+                      colIdx % 2 === 0
+                        ? "text-center text-white/70"
+                        : "text-center font-semibold text-amber-300";
+                    return (
+                      <div key={key} className={cellClass}>
+                        {display}
+                      </div>
+                    );
+                  })}
+
+                  <div className={`text-center font-black ${ppaValueClass(player.ppaValue, { authed })}`}>
+                    {formatPpa(player.ppaValue)}
+                  </div>
+
+                  <div className="flex items-center justify-center gap-2">
+                    {status.kind !== "available" ? (
+                      <div className={`rounded-xl border px-3 py-2 text-xs font-black ${pickedAccent?.header ?? ""}`}>
+                        {status.label}
+                      </div>
+                    ) : authed ? (
+                      <>
+                        <button
+                          onClick={() => onAddPick(player)}
+                          className="rounded-xl bg-emerald-500/15 px-3 py-2 text-xs font-black text-emerald-200 ring-1 ring-emerald-400/20 transition hover:bg-emerald-500/25"
+                        >
+                          Add
+                        </button>
+                        <button
+                          onClick={() => onTakenPick(player)}
+                          className="rounded-xl bg-rose-500/15 px-3 py-2 text-xs font-black text-rose-200 ring-1 ring-rose-400/20 transition hover:bg-rose-500/25"
+                        >
+                          Taken
+                        </button>
+                      </>
+                    ) : (
+                      <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-black text-white/40 blur-[1px]">
+                        Sign in required
+                      </div>
+                    )}
+                  </div>
+
+                  <div className="flex items-center justify-center">
+                    <button
+                      type="button"
+                      disabled={!authed}
+                      onClick={() => onToggleCompare(player.id)}
+                      className={[
+                        "relative h-6 w-14 rounded-full border transition",
+                        compareActive
+                          ? "border-emerald-300/70 bg-emerald-500/70 shadow-[0_0_12px_rgba(16,185,129,0.5)]"
+                          : "border-white/10 bg-white/5 hover:bg-white/10",
+                        !authed ? "opacity-40" : "",
+                      ].join(" ")}
+                      title={!authed ? "Sign in required" : compareRole ? `Selected ${compareRole}` : "Select for compare"}
+                    >
+                      <span
+                        className={[
+                          "absolute left-1 top-1 h-4 w-4 rounded-full bg-white transition-transform duration-200",
+                          compareActive ? "translate-x-8" : "translate-x-0",
+                        ].join(" ")}
+                      />
+                      {compareRole && (
+                        <span className="absolute left-2 top-1/2 -translate-y-1/2 text-[10px] font-black text-emerald-950">
+                          {compareRole}
+                        </span>
+                      )}
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+        </div>
+
+        <div className="border-t border-white/10 px-4 py-3 text-xs text-white/45">
+          Players and draft picks are loaded from backend APIs.
+        </div>
+      </section>
+
+      <Pagination page={page} totalPages={totalPages} onChange={onChangePage} />
+    </FadeIn>
+  );
+}

--- a/fe/src/features/draft/components/PlayerSearchToolbar.tsx
+++ b/fe/src/features/draft/components/PlayerSearchToolbar.tsx
@@ -1,0 +1,97 @@
+// Search + sort + position chips + "Customize Stats" trigger row that sits
+// above the player list. Presentation only: every value and callback flows
+// through props from DraftPage.
+
+import FadeIn from "../../../components/ui/FadeIn";
+import Dropdown from "../../../components/ui/Dropdown";
+import type { DraftPositionFilter, DraftSort } from "../../../types/draft";
+
+type Props = {
+  query: string;
+  onChangeQuery: (next: string) => void;
+  sort: DraftSort;
+  sortOptions: { value: DraftSort; label: string }[];
+  onChangeSort: (next: DraftSort) => void;
+  positionFilters: readonly DraftPositionFilter[];
+  position: DraftPositionFilter;
+  onChangePosition: (next: DraftPositionFilter) => void;
+  hasDraftConfig: boolean;
+  remainingBudget: number;
+  onOpenCustomizeStats: () => void;
+};
+
+export default function PlayerSearchToolbar({
+  query,
+  onChangeQuery,
+  sort,
+  sortOptions,
+  onChangeSort,
+  positionFilters,
+  position,
+  onChangePosition,
+  hasDraftConfig,
+  remainingBudget,
+  onOpenCustomizeStats,
+}: Props) {
+  return (
+    <FadeIn delayMs={100} className="relative z-40">
+      <section className="rounded-3xl border border-white/10 bg-white/5 p-5">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
+          <div className="w-full lg:max-w-md">
+            <div className="text-xs font-extrabold text-white/70">Search</div>
+            <input
+              value={query}
+              onChange={(e) => onChangeQuery(e.target.value)}
+              placeholder="Search player name..."
+              className="mt-2 w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm font-semibold text-white outline-none placeholder:text-white/40 focus:border-white/25"
+            />
+          </div>
+
+          <div className="w-full lg:w-72">
+            <Dropdown<DraftSort>
+              label="Sort"
+              value={sort}
+              options={sortOptions}
+              onChange={onChangeSort}
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          {positionFilters.map((filterValue) => {
+            const active = position === filterValue;
+            return (
+              <button
+                key={filterValue}
+                onClick={() => onChangePosition(filterValue)}
+                className={[
+                  "rounded-full px-3 py-1 text-xs font-extrabold transition",
+                  active
+                    ? "bg-white text-black"
+                    : "border border-white/10 bg-white/5 text-white/80 hover:bg-white/10",
+                ].join(" ")}
+              >
+                {filterValue}
+              </button>
+            );
+          })}
+
+          {hasDraftConfig && (
+            <div className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-3 py-1 text-xs font-black text-emerald-300">
+              Remaining Budget: ${remainingBudget}
+            </div>
+          )}
+
+          <button
+            type="button"
+            onClick={onOpenCustomizeStats}
+            className="ml-auto rounded-full border border-white/20 bg-white px-3 py-1 text-xs font-extrabold text-zinc-900 transition hover:bg-zinc-100"
+            title="Pick which 5 stats appear in the table"
+          >
+            Customize Stats
+          </button>
+        </div>
+      </section>
+    </FadeIn>
+  );
+}

--- a/fe/src/features/draft/components/SaveSessionModal.tsx
+++ b/fe/src/features/draft/components/SaveSessionModal.tsx
@@ -1,0 +1,74 @@
+// Save modal — name input + Cancel / Save buttons. Presentation only:
+// API calls and state live in the parent (DraftPage). Rendered conditionally
+// by the parent so we don't carry an `open` prop here.
+
+type Props = {
+  isLoadedMode: boolean;
+  nameInput: string;
+  onChangeName: (next: string) => void;
+  error: string | null;
+  saving: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export default function SaveSessionModal({
+  isLoadedMode,
+  nameInput,
+  onChangeName,
+  error,
+  saving,
+  onCancel,
+  onConfirm,
+}: Props) {
+  return (
+    <div className="fixed inset-0 z-[80] grid place-items-center p-4">
+      <button
+        type="button"
+        aria-label="Close save dialog"
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onCancel}
+      />
+      <div className="relative w-full max-w-md rounded-3xl border border-white/15 bg-[#0c1220] p-6 shadow-2xl">
+        <div className="text-lg font-black text-white">
+          {isLoadedMode ? "Save Changes" : "Save Draft"}
+        </div>
+        <div className="mt-1 text-xs text-white/55">
+          Enter a session name (up to 3 saved sessions)
+        </div>
+
+        <input
+          type="text"
+          value={nameInput}
+          onChange={(e) => onChangeName(e.target.value)}
+          placeholder="e.g. 2026 Black Sluggers"
+          className="mt-4 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm font-semibold text-white outline-none placeholder:text-white/40 focus:border-white/25"
+          autoFocus
+        />
+
+        {error && (
+          <div className="mt-2 text-xs font-bold text-rose-300">{error}</div>
+        )}
+
+        <div className="mt-5 flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={saving}
+            className="flex-1 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-black text-white/80 transition hover:bg-white/10 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={saving}
+            className="flex-1 rounded-2xl bg-emerald-500 px-4 py-3 text-sm font-black text-white transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/draft/draftHelpers.ts
+++ b/fe/src/features/draft/draftHelpers.ts
@@ -1,0 +1,198 @@
+// Pure helpers + constants + response/payload types extracted from DraftPage.tsx
+// so the page component can focus on orchestration. Anything in this file is
+// React-free and safe to import from anywhere in the draft feature.
+
+import type {
+  DraftConfigServer,
+  DraftPick,
+  DraftPlayer,
+  DraftPlayerPublic,
+  DraftPlayerValue,
+  DraftPositionFilter,
+  DraftSort,
+  DraftTeam,
+  SessionSummary,
+} from "../../types/draft";
+import { DEFAULT_ROSTER_SLOTS, formatAvg, sumRosterSlots } from "./utils";
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+export const UNSAVED_DRAFT_KEY = "ppadun_unsaved_draft";
+
+export const DEFAULT_DRAFT_CONFIG: DraftConfigServer = {
+  leagueType: "AL",
+  budget: 260,
+  rosterPlayers: sumRosterSlots(DEFAULT_ROSTER_SLOTS),
+  myTeamName: "My Team",
+  opponentsCount: 11,
+  oppTeamNames: Array.from({ length: 11 }, (_, i) => `Opponent ${i + 1}`),
+  rosterSlots: DEFAULT_ROSTER_SLOTS,
+};
+
+export const DEFAULT_POSITION_FILTERS: DraftPositionFilter[] = [
+  "C", "1B", "2B", "3B", "SS", "OF", "UTIL", "SP", "RP",
+];
+
+export const BATTER_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
+  { value: "score_desc", label: "By Score" },
+  { value: "cost_desc",  label: "By Draft Cost" },
+  { value: "avg_desc",   label: "By AVG" },
+  { value: "hr_desc",    label: "By HR" },
+  { value: "rbi_desc",   label: "By RBI" },
+  { value: "sb_desc",    label: "By SB" },
+];
+
+export const PITCHER_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
+  { value: "score_desc", label: "By Score" },
+  { value: "cost_desc",  label: "By Draft Cost" },
+  { value: "avg_desc",   label: "By ERA" },
+  { value: "hr_desc",    label: "By SO" },
+  { value: "rbi_desc",   label: "By W" },
+  { value: "sb_desc",    label: "By SV" },
+];
+
+// ── Inline API response & sessionStorage payload types ────────────────
+
+export type DraftPlayersResponse = { items: DraftPlayerPublic[] };
+export type DraftPlayerValuesResponse = { items: DraftPlayerValue[] };
+export type SessionsListResponse = { items: SessionSummary[] };
+
+// sessionStorage 페이로드 — DraftSetupCard 가 쓰고 DraftPage 가 읽는다.
+// 같은 탭에서 페이지 이동/새로고침 동안만 유지, 창을 닫으면 사라짐.
+export type UnsavedDraft = {
+  config: DraftConfigServer;
+  picks: DraftPick[];
+  notes?: Record<string, string>; // playerId → note (저장 전 클라이언트 보관)
+};
+
+// ── Filtering / predicates ────────────────────────────────────────────
+
+// 모든 필터는 정확한 포지션 일치 — UTIL 칩은 "UTIL 자격" 보유 선수만 골라낸다.
+export function matchesPositionFilter(
+  playerPositions: readonly string[] | undefined,
+  filter: DraftPositionFilter,
+): boolean {
+  if (!playerPositions || playerPositions.length === 0) return false;
+  const normalized = playerPositions.map((p) => p.toUpperCase());
+  return normalized.includes(filter);
+}
+
+export function isPitcherOnly(player: DraftPlayerPublic): boolean {
+  return player.playerType === "pitcher";
+}
+
+export function isPitcherPositionFilter(filter: DraftPositionFilter): boolean {
+  return filter === "SP" || filter === "RP";
+}
+
+// ── Formatters ────────────────────────────────────────────────────────
+
+export function formatNumber(value: number | null | undefined, digits: number) {
+  if (value === null || value === undefined) return "-";
+  return value.toFixed(digits);
+}
+
+export function formatDraftStatSummary(player: DraftPlayerPublic) {
+  if (isPitcherOnly(player)) {
+    return `ERA ${formatNumber(player.era, 2)} | SO ${player.so ?? "-"} | W ${player.w ?? "-"} | SV ${player.sv ?? "-"} | IP ${formatNumber(player.ip, 1)}`;
+  }
+  return `AVG ${formatAvg(player.avg)} | HR ${player.hr ?? "-"} | RBI ${player.rbi ?? "-"} | SB ${player.sb ?? "-"} | AB ${player.ab ?? "-"}`;
+}
+
+// ── Sort-value accessors (pitcher / batter dispatch) ──────────────────
+
+export function primaryRateSortValue(player: DraftPlayerPublic) {
+  if (isPitcherOnly(player)) {
+    return player.era === null || player.era === undefined ? 0 : -player.era;
+  }
+  return player.avg ?? 0;
+}
+
+export function powerSortValue(player: DraftPlayerPublic) {
+  return isPitcherOnly(player) ? player.so ?? 0 : player.hr ?? 0;
+}
+
+export function productionSortValue(player: DraftPlayerPublic) {
+  return isPitcherOnly(player) ? player.w ?? 0 : player.rbi ?? 0;
+}
+
+export function speedSortValue(player: DraftPlayerPublic) {
+  return isPitcherOnly(player) ? player.sv ?? 0 : player.sb ?? 0;
+}
+
+// ── sessionStorage I/O (with legacy localStorage fallback) ────────────
+
+export function removeUnsavedDraftStorage() {
+  sessionStorage.removeItem(UNSAVED_DRAFT_KEY);
+  localStorage.removeItem(UNSAVED_DRAFT_KEY);
+}
+
+export function readUnsavedDraftStorage(): string | null {
+  const current = sessionStorage.getItem(UNSAVED_DRAFT_KEY);
+  if (current) return current;
+
+  const legacy = localStorage.getItem(UNSAVED_DRAFT_KEY);
+  if (!legacy) return null;
+
+  // Migrate legacy localStorage payload into the per-tab sessionStorage.
+  sessionStorage.setItem(UNSAVED_DRAFT_KEY, legacy);
+  localStorage.removeItem(UNSAVED_DRAFT_KEY);
+  return legacy;
+}
+
+// ── Data shaping ──────────────────────────────────────────────────────
+
+// 미저장 모드에서 config 만으로 teams 배열을 만든다.
+// 저장 시 서버가 자체 ID 로 다시 만들어 주므로 여기 ID 는 클라이언트 임시 키.
+export function buildTeamsFromConfig(config: DraftConfigServer): DraftTeam[] {
+  const teams: DraftTeam[] = [
+    { id: "team-0", name: config.myTeamName, isMine: true },
+  ];
+  for (let i = 0; i < config.opponentsCount; i += 1) {
+    teams.push({
+      id: `team-${i + 1}`,
+      name: config.oppTeamNames[i] ?? `Opponent ${i + 1}`,
+      isMine: false,
+    });
+  }
+  return teams;
+}
+
+export function normalizeDraftTeamId(teamId: string) {
+  if (teamId === "me" || teamId === "team-me") return "team-0";
+  const legacyOpponent = /^opp(\d+)$/.exec(teamId);
+  if (legacyOpponent) return `team-${Number(legacyOpponent[1]) + 1}`;
+  return teamId;
+}
+
+export function normalizeDraftPicks(picks: DraftPick[]): DraftPick[] {
+  return picks.map((pick) => ({
+    ...pick,
+    draftedByTeamId: normalizeDraftTeamId(pick.draftedByTeamId),
+    // 옛 localStorage / 세션엔 kind 가 없을 수 있어 main 폴백.
+    kind: pick.kind ?? "main",
+  }));
+}
+
+// 공개 선수 목록과 인증 값 목록을 playerId 기준으로 머지
+export function mergePlayersWithValues(
+  publicPlayers: DraftPlayerPublic[],
+  values: DraftPlayerValue[] | null,
+): DraftPlayer[] {
+  if (!values) return publicPlayers.map((player) => ({ ...player }));
+
+  const valueById = new Map(values.map((v) => [v.playerId, v]));
+  return publicPlayers.map((player) => {
+    const v = valueById.get(player.id);
+    return v
+      ? { ...player, ppaValue: v.ppaValue, recommendedBid: v.recommendedBid }
+      : { ...player };
+  });
+}
+
+// "Untitled Draft" 같은 자동 이름은 Save 모달에서 빈 입력으로 시작해야 한다.
+export function initialNameFor(currentName: string | null): string {
+  if (!currentName) return "";
+  if (currentName === "Untitled Draft") return "";
+  return currentName;
+}

--- a/fe/src/features/draft/useDraftSessionLoader.ts
+++ b/fe/src/features/draft/useDraftSessionLoader.ts
@@ -1,0 +1,141 @@
+// Loads the draft session on mount.
+//
+// Two cooperating effects:
+// 1. Bootstrap — branches on URL mode.
+//    - Loaded mode (`/draft/:sessionId`)   → GET session detail, hydrate state.
+//      Redirects to "/" on 404 / other errors.
+//    - Unsaved mode (`/draft`)             → read sessionStorage and resume,
+//      otherwise fall back to DEFAULT_DRAFT_CONFIG so the player browser shows
+//      a default roster shape.
+// 2. Notes fetch — only in loaded mode, fetches the saved per-player notes
+//    via a separate endpoint and merges into the parent's notes state.
+//    (Unsaved mode picks up notes from sessionStorage in step 1.)
+//
+// State is owned by DraftPage; this hook just runs the side effects against
+// setters passed in. That keeps the rest of the page unchanged.
+
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { apiGetAuth } from "../../lib/api";
+import type {
+  DraftConfigServer,
+  DraftPick,
+  DraftTeam,
+  PlayerNote,
+  SessionDetail,
+} from "../../types/draft";
+import {
+  DEFAULT_DRAFT_CONFIG,
+  buildTeamsFromConfig,
+  normalizeDraftPicks,
+  readUnsavedDraftStorage,
+  type UnsavedDraft,
+} from "./draftHelpers";
+
+type Params = {
+  isLoadedMode: boolean;
+  sessionId: number | null;
+  setConfig: (config: DraftConfigServer) => void;
+  setHasDraftConfig: (next: boolean) => void;
+  setTeams: (teams: DraftTeam[]) => void;
+  setSessionName: (name: string | null) => void;
+  setBootstrapped: (next: boolean) => void;
+  setNotes: (notes: Record<string, string>) => void;
+  resetPicks: (picks: DraftPick[]) => void;
+};
+
+export function useDraftSessionLoader({
+  isLoadedMode,
+  sessionId,
+  setConfig,
+  setHasDraftConfig,
+  setTeams,
+  setSessionName,
+  setBootstrapped,
+  setNotes,
+  resetPicks,
+}: Params) {
+  const navigate = useNavigate();
+
+  // 마운트 분기:
+  //  - sessionId 있음(로드 모드): GET /api/draft/sessions/{id}. 404 → 홈.
+  //  - 그 외(미저장 모드): sessionStorage 에서 unsaved draft 를 복원하거나
+  //    DEFAULT_DRAFT_CONFIG 로 player browser 시작.
+  useEffect(() => {
+    if (isLoadedMode) {
+      const controller = new AbortController();
+
+      apiGetAuth<SessionDetail>(
+        `/api/draft/sessions/${sessionId}`,
+        undefined,
+        controller.signal,
+      )
+        .then((data) => {
+          if (controller.signal.aborted) return;
+          setConfig(data.config);
+          setHasDraftConfig(true);
+          setTeams(data.teams);
+          resetPicks(normalizeDraftPicks(data.picks ?? []));
+          setSessionName(data.name);
+          setBootstrapped(true);
+        })
+        .catch((err: unknown) => {
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          console.error(err);
+          // 404 또는 기타 실패 → 홈으로
+          navigate("/", { replace: true });
+        });
+
+      return () => controller.abort();
+    }
+
+    // 미저장 모드 — sessionStorage 가 있으면 resume, 없으면 default config.
+    let parsed: UnsavedDraft | null = null;
+    try {
+      const raw = readUnsavedDraftStorage();
+      if (raw) parsed = JSON.parse(raw) as UnsavedDraft;
+    } catch {
+      parsed = null;
+    }
+
+    const ready: UnsavedDraft = parsed?.config
+      ? parsed
+      : { config: DEFAULT_DRAFT_CONFIG, picks: [] };
+    queueMicrotask(() => {
+      setConfig(ready.config);
+      setHasDraftConfig(Boolean(parsed?.config));
+      setTeams(buildTeamsFromConfig(ready.config));
+      resetPicks(normalizeDraftPicks(ready.picks ?? []));
+      setNotes(ready.notes ?? {});
+      setSessionName(null);
+      setBootstrapped(true);
+    });
+    // Setters are stable; only branch keys matter for re-run.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoadedMode, navigate, sessionId]);
+
+  // 로드 모드 전용 — 서버에서 메모 가져오기. 미저장 모드는 위 effect 가 sessionStorage 에서 채워줌.
+  useEffect(() => {
+    if (!isLoadedMode || sessionId === null) return;
+    const controller = new AbortController();
+    apiGetAuth<{ items: PlayerNote[] }>(
+      `/api/draft/sessions/${sessionId}/notes`,
+      undefined,
+      controller.signal,
+    )
+      .then((data) => {
+        if (controller.signal.aborted) return;
+        const map: Record<string, string> = {};
+        for (const it of data.items ?? []) map[it.playerId] = it.note;
+        setNotes(map);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.error(err);
+        setNotes({});
+      });
+    return () => controller.abort();
+    // setNotes is stable.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoadedMode, sessionId]);
+}

--- a/fe/src/hooks/useUndoKeyboardShortcuts.ts
+++ b/fe/src/hooks/useUndoKeyboardShortcuts.ts
@@ -1,0 +1,72 @@
+// Keyboard shortcuts for undo / redo.
+//
+//   Undo : Ctrl + Z (Win/Linux) or Cmd + Z (macOS)
+//   Redo : Ctrl + Y, Ctrl + Shift + Z, or Cmd + Shift + Z
+//
+// Skips events that originate from text inputs / textareas / contenteditable
+// elements so the browser's native undo keeps working while editing text
+// (search box, note popover, save-name input, etc.).
+//
+// Caller passes in `onUndo` / `onRedo` along with `canUndo` / `canRedo`
+// flags; nothing fires when there's nothing to undo / redo. The handler
+// is registered on `window` for the lifetime of the component using the
+// hook, then cleaned up on unmount.
+
+import { useEffect } from "react";
+
+type Params = {
+  onUndo: () => void;
+  onRedo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  enabled?: boolean; // optional master switch
+};
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+export function useUndoKeyboardShortcuts({
+  onUndo,
+  onRedo,
+  canUndo,
+  canRedo,
+  enabled = true,
+}: Params) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Modifier required — Ctrl on Win/Linux, Meta (⌘) on macOS.
+      const mod = e.ctrlKey || e.metaKey;
+      if (!mod) return;
+
+      // Let the browser handle native undo inside editable fields.
+      if (isEditableTarget(e.target)) return;
+
+      const key = e.key.toLowerCase();
+
+      // Redo: Ctrl+Y, or Ctrl/Cmd+Shift+Z
+      if (key === "y" || (key === "z" && e.shiftKey)) {
+        if (!canRedo) return;
+        e.preventDefault();
+        onRedo();
+        return;
+      }
+
+      // Undo: Ctrl/Cmd+Z (without shift)
+      if (key === "z") {
+        if (!canUndo) return;
+        e.preventDefault();
+        onUndo();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onUndo, onRedo, canUndo, canRedo, enabled]);
+}

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -16,8 +16,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import FadeIn from "../components/ui/FadeIn";
-import Skeleton from "../components/ui/Skeleton";
-import Dropdown from "../components/ui/Dropdown";
 import { useAuth } from "../lib/auth";
 import { apiGet, apiGetAuth, apiPostAuth, apiPutAuth, apiDeleteAuth } from "../lib/api";
 
@@ -31,7 +29,6 @@ import type {
   DraftPositionFilter,
   DraftSort,
   DraftTeam,
-  PlayerNote,
   SessionDetail,
   SessionSummary,
 } from "../types/draft";
@@ -44,17 +41,31 @@ import {
   calculateCurrentRound,
   calculateRemainingBudget,
   clampRosterSize,
-  draftCostClass,
   findEligibleSlotIndex,
   findFirstEmptySlot,
-  formatAvg,
-  getPlayerDraftStatus,
   isEligibleForSlot,
-  mlbTeamBadgeClass,
-  sumRosterSlots,
-  teamAccentClass,
 } from "../features/draft/utils";
-import { formatPpa, ppaValueClass } from "../utils/playerValue";
+import {
+  BATTER_SORT_OPTIONS,
+  DEFAULT_DRAFT_CONFIG,
+  DEFAULT_POSITION_FILTERS,
+  PITCHER_SORT_OPTIONS,
+  UNSAVED_DRAFT_KEY,
+  buildTeamsFromConfig,
+  initialNameFor,
+  isPitcherPositionFilter,
+  matchesPositionFilter,
+  mergePlayersWithValues,
+  powerSortValue,
+  primaryRateSortValue,
+  productionSortValue,
+  removeUnsavedDraftStorage,
+  speedSortValue,
+  type DraftPlayersResponse,
+  type DraftPlayerValuesResponse,
+  type SessionsListResponse,
+  type UnsavedDraft,
+} from "../features/draft/draftHelpers";
 
 import DraftRoomBoard from "../features/draft/components/DraftRoomBoard";
 import AddBidModal from "../features/draft/components/AddBidModal";
@@ -62,209 +73,34 @@ import TakenBidModal from "../features/draft/components/TakenBidModal";
 import PlayerComparisonModal from "../features/draft/components/PlayerComparisonModal";
 import PlayerNotePopover from "../features/draft/components/PlayerNotePopover";
 import CustomizeStatsModal from "../features/draft/components/CustomizeStatsModal";
+import SaveSessionModal from "../features/draft/components/SaveSessionModal";
+import ImportSessionsModal from "../features/draft/components/ImportSessionsModal";
+import PlayerListTable from "../features/draft/components/PlayerListTable";
+import DraftHeaderBar from "../features/draft/components/DraftHeaderBar";
+import PlayerSearchToolbar from "../features/draft/components/PlayerSearchToolbar";
+import ComparisonPanel from "../features/draft/components/ComparisonPanel";
 import { useStatColumns } from "../features/draft/useStatColumns";
 import { getStatDef } from "../features/draft/statColumns";
+import { useDraftSessionLoader } from "../features/draft/useDraftSessionLoader";
 import { useNotificationPolling } from "../hooks/useNotificationPolling";
 import type { NotificationEvent } from "../types/notifications";
 import PlayerInfoModal from "../features/players/components/PlayerInfoModal";
-import Pagination from "../features/players/components/Pagination";
 import Modal from "../components/ui/Modal";
 import Toast, { type ToastMessage, type ToastVariant } from "../components/ui/Toast";
 import { useUndoStack } from "../hooks/useUndoStack";
+import { useUndoKeyboardShortcuts } from "../hooks/useUndoKeyboardShortcuts";
 import DraftSetupCard, { type DraftSetupConfig } from "../features/home/DraftSetupCard";
 import LoginPromptModal from "../features/auth/LoginPromptModal";
 
 const PAGE_SIZE = 30;
 
-const DEFAULT_POSITION_FILTERS: DraftPositionFilter[] = [
-  "C",
-  "1B",
-  "2B",
-  "3B",
-  "SS",
-  "OF",
-  "UTIL",
-  "SP",
-  "RP",
-];
-
-// Match a player against a position filter.
-// 모든 필터는 정확한 포지션 일치 — UTIL 칩은 "UTIL 자격이 있는 선수"만 골라낸다.
-// (예전엔 UTIL 이 "투수가 아닌 모든 선수"였는데, 그건 사실상 "전체 타자" 필터라
-//  포지션 칩의 의미와 맞지 않아 정확 일치로 바꿈.)
-function matchesPositionFilter(
-  playerPositions: readonly string[] | undefined,
-  filter: DraftPositionFilter
-): boolean {
-  if (!playerPositions || playerPositions.length === 0) return false;
-
-  const normalized = playerPositions.map((p) => p.toUpperCase());
-  return normalized.includes(filter);
-}
-
-function isPitcherOnly(player: DraftPlayerPublic): boolean {
-  return player.playerType === "pitcher";
-}
-
-function isPitcherPositionFilter(filter: DraftPositionFilter): boolean {
-  return filter === "SP" || filter === "RP";
-}
-
-function formatNumber(value: number | null | undefined, digits: number) {
-  if (value === null || value === undefined) return "-";
-  return value.toFixed(digits);
-}
-
-function formatDraftStatSummary(player: DraftPlayerPublic) {
-  if (isPitcherOnly(player)) {
-    return `ERA ${formatNumber(player.era, 2)} | SO ${player.so ?? "-"} | W ${player.w ?? "-"} | SV ${player.sv ?? "-"} | IP ${formatNumber(player.ip, 1)}`;
-  }
-  return `AVG ${formatAvg(player.avg)} | HR ${player.hr ?? "-"} | RBI ${player.rbi ?? "-"} | SB ${player.sb ?? "-"} | AB ${player.ab ?? "-"}`;
-}
-
-function primaryRateSortValue(player: DraftPlayerPublic) {
-  if (isPitcherOnly(player)) {
-    return player.era === null || player.era === undefined ? 0 : -player.era;
-  }
-  return player.avg ?? 0;
-}
-
-function powerSortValue(player: DraftPlayerPublic) {
-  return isPitcherOnly(player) ? player.so ?? 0 : player.hr ?? 0;
-}
-
-function productionSortValue(player: DraftPlayerPublic) {
-  return isPitcherOnly(player) ? player.w ?? 0 : player.rbi ?? 0;
-}
-
-function speedSortValue(player: DraftPlayerPublic) {
-  return isPitcherOnly(player) ? player.sv ?? 0 : player.sb ?? 0;
-}
-
-const BATTER_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
-  { value: "score_desc", label: "By Score" },
-  { value: "cost_desc", label: "By Draft Cost" },
-  { value: "avg_desc", label: "By AVG" },
-  { value: "hr_desc", label: "By HR" },
-  { value: "rbi_desc", label: "By RBI" },
-  { value: "sb_desc", label: "By SB" },
-];
-
-const PITCHER_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
-  { value: "score_desc", label: "By Score" },
-  { value: "cost_desc", label: "By Draft Cost" },
-  { value: "avg_desc", label: "By ERA" },
-  { value: "hr_desc", label: "By SO" },
-  { value: "rbi_desc", label: "By W" },
-  { value: "sb_desc", label: "By SV" },
-];
-
-// 공개 /api/draft/players — PPA 값 / 추천 bid 없이 전체 선수 목록만
-type DraftPlayersResponse = {
-  items: DraftPlayerPublic[];
-};
-
-// POST /api/draft/players/values — body { config, picks } → 값 목록
-type DraftPlayerValuesResponse = {
-  items: DraftPlayerValue[];
-};
-
-// GET /api/draft/sessions — Import 모달용 목록
-type SessionsListResponse = {
-  items: SessionSummary[];
-};
-
-const UNSAVED_DRAFT_KEY = "ppadun_unsaved_draft";
-
-const DEFAULT_DRAFT_CONFIG: DraftConfigServer = {
-  leagueType: "AL",
-  budget: 260,
-  rosterPlayers: sumRosterSlots(DEFAULT_ROSTER_SLOTS),
-  myTeamName: "My Team",
-  opponentsCount: 11,
-  oppTeamNames: Array.from({ length: 11 }, (_, i) => `Opponent ${i + 1}`),
-  rosterSlots: DEFAULT_ROSTER_SLOTS,
-};
-
-// 미저장 모드의 sessionStorage 페이로드 — DraftSetupCard 가 쓰고 DraftPage 가 읽음.
-// 같은 탭에서 페이지 이동/새로고침 동안 유지되고, 창을 닫으면 브라우저가 지운다.
-type UnsavedDraft = {
-  config: DraftConfigServer;
-  picks: DraftPick[];
-  notes?: Record<string, string>; // playerId → note (미저장 동안 클라이언트 보관)
-};
-
-function removeUnsavedDraftStorage() {
-  sessionStorage.removeItem(UNSAVED_DRAFT_KEY);
-  localStorage.removeItem(UNSAVED_DRAFT_KEY);
-}
-
-function readUnsavedDraftStorage() {
-  const current = sessionStorage.getItem(UNSAVED_DRAFT_KEY);
-  if (current) return current;
-
-  const legacy = localStorage.getItem(UNSAVED_DRAFT_KEY);
-  if (!legacy) return null;
-
-  sessionStorage.setItem(UNSAVED_DRAFT_KEY, legacy);
-  localStorage.removeItem(UNSAVED_DRAFT_KEY);
-  return legacy;
-}
-
-// 미저장 모드에서 config 만으로 teams 배열을 만든다.
-// 저장 시 서버가 자체 ID 로 다시 만들어 주므로 여기 ID 는 클라이언트 임시 키로만 사용.
-function buildTeamsFromConfig(config: DraftConfigServer): DraftTeam[] {
-  const teams: DraftTeam[] = [
-    { id: "team-0", name: config.myTeamName, isMine: true },
-  ];
-  for (let i = 0; i < config.opponentsCount; i += 1) {
-    teams.push({
-      id: `team-${i + 1}`,
-      name: config.oppTeamNames[i] ?? `Opponent ${i + 1}`,
-      isMine: false,
-    });
-  }
-  return teams;
-}
-
-function normalizeDraftTeamId(teamId: string) {
-  if (teamId === "me" || teamId === "team-me") return "team-0";
-  const legacyOpponent = /^opp(\d+)$/.exec(teamId);
-  if (legacyOpponent) return `team-${Number(legacyOpponent[1]) + 1}`;
-  return teamId;
-}
-
-function normalizeDraftPicks(picks: DraftPick[]): DraftPick[] {
-  return picks.map((pick) => ({
-    ...pick,
-    draftedByTeamId: normalizeDraftTeamId(pick.draftedByTeamId),
-    // 옛 localStorage / 세션엔 kind 가 없을 수 있어 main 폴백.
-    kind: pick.kind ?? "main",
-  }));
-}
-
-// 공개 선수 목록과 인증 값 목록을 playerId 기준으로 머지
-function mergePlayersWithValues(
-  publicPlayers: DraftPlayerPublic[],
-  values: DraftPlayerValue[] | null
-): DraftPlayer[] {
-  if (!values) return publicPlayers.map((player) => ({ ...player }));
-
-  const valueById = new Map(values.map((v) => [v.playerId, v]));
-  return publicPlayers.map((player) => {
-    const v = valueById.get(player.id);
-    return v
-      ? { ...player, ppaValue: v.ppaValue, recommendedBid: v.recommendedBid }
-      : { ...player };
-  });
-}
-
-// "Untitled Draft" 같은 자동 이름은 Save 모달에서 빈 입력으로 시작해야 한다.
-function initialNameFor(currentName: string | null): string {
-  if (!currentName) return "";
-  if (currentName === "Untitled Draft") return "";
-  return currentName;
-}
+// Pure helpers, constants, and inline response/payload types live in
+// `draftHelpers.ts` so this file stays focused on orchestration. See that
+// module for: matchesPositionFilter, isPitcherOnly, isPitcherPositionFilter,
+// formatNumber, formatDraftStatSummary, sort-value accessors,
+// buildTeamsFromConfig, normalizeDraftPicks, mergePlayersWithValues,
+// readUnsavedDraftStorage / removeUnsavedDraftStorage, DEFAULT_DRAFT_CONFIG,
+// DEFAULT_POSITION_FILTERS, BATTER_/PITCHER_SORT_OPTIONS, etc.
 
 export default function DraftPage() {
   const authed = useAuth();
@@ -312,6 +148,15 @@ export default function DraftPage() {
     canUndo: canUndoPicks,
     canRedo: canRedoPicks,
   } = useUndoStack<DraftPick[]>([]);
+
+  // 키보드 단축키 — Ctrl/Cmd+Z = undo, Ctrl+Y / Ctrl·Cmd+Shift+Z = redo.
+  // input / textarea / contenteditable 안에서는 무시 (브라우저 기본 undo 유지).
+  useUndoKeyboardShortcuts({
+    onUndo: undoPicks,
+    onRedo: redoPicks,
+    canUndo: canUndoPicks,
+    canRedo: canRedoPicks,
+  });
   const [sessionName, setSessionName] = useState<string | null>(null);
   const [bootstrapped, setBootstrapped] = useState(false);
 
@@ -632,85 +477,20 @@ export default function DraftPage() {
     setHasDraftConfig(false);
   };
 
-  // 마운트 분기:
-  //  - sessionId 있음(로드 모드): GET /api/draft/sessions/{id}. 404 → 홈.
-  //  - setup=1 있음(새 드래프트 모드): sessionStorage["ppadun_unsaved_draft"] 읽음.
-  //  - 둘 다 없으면 Default/Guest player browser로 시작하며 saved session은 Import로만 연다.
-  // 이후 모든 픽 변경은 React state 에서만 처리되며 서버에 즉시 반영되지 않는다.
-  useEffect(() => {
-    if (isLoadedMode) {
-      const controller = new AbortController();
-
-      apiGetAuth<SessionDetail>(
-        `/api/draft/sessions/${sessionId}`,
-        undefined,
-        controller.signal
-      )
-        .then((data) => {
-          if (controller.signal.aborted) return;
-          setConfig(data.config);
-          setHasDraftConfig(true);
-          setTeams(data.teams);
-          resetPicks(normalizeDraftPicks(data.picks ?? []));
-          setSessionName(data.name);
-          setBootstrapped(true);
-        })
-        .catch((err: unknown) => {
-          if (err instanceof DOMException && err.name === "AbortError") return;
-          console.error(err);
-          // 404 또는 기타 실패 → 홈으로
-          navigate("/", { replace: true });
-        });
-
-      return () => controller.abort();
-    }
-
-    // 미저장 모드 — sessionStorage에 unsaved draft가 있으면 자동 resume.
-    // 없으면 default config로 player browser 모드 (Start Your Draft 버튼 노출).
-    let parsed: UnsavedDraft | null = null;
-    try {
-      const raw = readUnsavedDraftStorage();
-      if (raw) parsed = JSON.parse(raw) as UnsavedDraft;
-    } catch {
-      parsed = null;
-    }
-
-    const ready: UnsavedDraft = parsed?.config
-      ? parsed
-      : { config: DEFAULT_DRAFT_CONFIG, picks: [] };
-    queueMicrotask(() => {
-      setConfig(ready.config);
-      setHasDraftConfig(Boolean(parsed?.config));
-      setTeams(buildTeamsFromConfig(ready.config));
-      resetPicks(normalizeDraftPicks(ready.picks ?? []));
-      setNotes(ready.notes ?? {});
-      setSessionName(null);
-      setBootstrapped(true);
-    });
-  }, [isLoadedMode, navigate, sessionId]);
-
-  // 로드 모드 — 서버에서 메모를 가져온다. 미저장 모드는 부트스트랩 effect 가 sessionStorage 에서 채워주므로 여기선 건드리지 않음.
-  useEffect(() => {
-    if (!isLoadedMode || sessionId === null) return;
-    const controller = new AbortController();
-    apiGetAuth<{ items: PlayerNote[] }>(
-      `/api/draft/sessions/${sessionId}/notes`,
-      undefined,
-      controller.signal
-    )
-      .then((data) => {
-        if (controller.signal.aborted) return;
-        const map: Record<string, string> = {};
-        for (const it of data.items ?? []) map[it.playerId] = it.note;
-        setNotes(map);
-      })
-      .catch((err: unknown) => {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        console.error(err);
-        setNotes({});
-      });
-    return () => controller.abort();
-  }, [isLoadedMode, sessionId]);
+  // 세션 부트스트랩 + 메모 패치 — 두 useEffect 를 캡슐화한 훅에 위임.
+  // 동작은 100% 동일: 로드 모드는 GET session detail + notes, 미저장 모드는
+  // sessionStorage 에서 resume 또는 DEFAULT_DRAFT_CONFIG 폴백.
+  useDraftSessionLoader({
+    isLoadedMode,
+    sessionId,
+    setConfig,
+    setHasDraftConfig,
+    setTeams,
+    setSessionName,
+    setBootstrapped,
+    setNotes,
+    resetPicks,
+  });
 
   // 미저장 모드에서 picks/notes 가 바뀔 때마다 sessionStorage 에도 sync — 페이지 이동/새로고침 보호.
   useEffect(() => {
@@ -1171,101 +951,22 @@ export default function DraftPage() {
 
   return (
     <div className="space-y-6">
-      <FadeIn>
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <div className="text-sm font-black text-white/70">PPA-DUN</div>
-            <h1 className="mt-1 text-3xl font-black text-white">
-              {sessionName ?? "Draft Room"}
-            </h1>
-            {hasDraftConfig ? (
-              <p className="mt-2 text-sm text-white/60">
-                {String(config.leagueType ?? "AL").toUpperCase()} - ${config.budget} Budget - {rosterSize} Players
-              </p>
-            ) : (
-              <p className="mt-2 text-sm text-white/60">
-                Browse players without starting a draft.
-              </p>
-            )}
-          </div>
-
-          <div className="flex items-center gap-2">
-            {hasDraftConfig && (
-              <>
-                <button
-                  type="button"
-                  onClick={undoPicks}
-                  disabled={!canUndoPicks}
-                  aria-label="Undo"
-                  className="grid h-12 w-12 place-items-center rounded-2xl border border-white/15 bg-black/25 text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black/25"
-                  title="Undo the last pick change"
-                >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
-                    <path d="M9 14l-4-4 4-4" />
-                    <path d="M5 10h11a4 4 0 0 1 0 8h-2" />
-                  </svg>
-                </button>
-                <button
-                  type="button"
-                  onClick={redoPicks}
-                  disabled={!canRedoPicks}
-                  aria-label="Redo"
-                  className="grid h-12 w-12 place-items-center rounded-2xl border border-white/15 bg-black/25 text-white/80 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black/25"
-                  title="Redo the last undone change"
-                >
-                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
-                    <path d="M15 14l4-4-4-4" />
-                    <path d="M19 10H8a4 4 0 0 0 0 8h2" />
-                  </svg>
-                </button>
-              </>
-            )}
-            {hasDraftConfig && (
-              <button
-                type="button"
-                onClick={handleDiscardDraft}
-                className="rounded-2xl border border-rose-400/30 bg-rose-500/10 px-4 py-3 text-sm font-black text-rose-200 transition hover:bg-rose-500/20"
-                title={
-                  isLoadedMode
-                    ? "Clear all picks of the current saved session"
-                    : "Discard the current unsaved draft and start over"
-                }
-              >
-                Discard
-              </button>
-            )}
-            {authed && (
-              <>
-                {hasDraftConfig && (
-                  <button
-                    type="button"
-                    onClick={openSaveModal}
-                    className="rounded-2xl border border-emerald-400/30 bg-emerald-500/10 px-4 py-3 text-sm font-black text-emerald-200 transition hover:bg-emerald-500/20"
-                    title="Save current draft as a session"
-                  >
-                    Save
-                  </button>
-                )}
-                <button
-                  type="button"
-                  onClick={openImportModal}
-                  className="rounded-2xl border border-white/15 bg-black/25 px-4 py-3 text-sm font-black text-white/80 transition hover:bg-white/10"
-                  title="Import a saved session"
-                >
-                  Import
-                </button>
-              </>
-            )}
-
-            {hasDraftConfig && (
-              <div className="rounded-2xl border border-white/10 bg-white/5 px-5 py-4">
-                <div className="text-xs font-extrabold text-white/60">Remaining Budget</div>
-                <div className="mt-1 text-2xl font-black text-emerald-400">${remainingBudget}</div>
-              </div>
-            )}
-          </div>
-        </div>
-      </FadeIn>
+      <DraftHeaderBar
+        sessionName={sessionName}
+        config={config}
+        hasDraftConfig={hasDraftConfig}
+        isLoadedMode={isLoadedMode}
+        rosterSize={rosterSize}
+        remainingBudget={remainingBudget}
+        authed={authed}
+        canUndoPicks={canUndoPicks}
+        canRedoPicks={canRedoPicks}
+        onUndo={undoPicks}
+        onRedo={redoPicks}
+        onDiscard={handleDiscardDraft}
+        onSave={openSaveModal}
+        onImport={openImportModal}
+      />
 
       <FadeIn delayMs={60}>
         <div ref={draftRoomTopRef}>
@@ -1305,387 +1006,63 @@ export default function DraftPage() {
         </div>
       </FadeIn>
 
-      <FadeIn delayMs={100} className="relative z-40">
-        <section className="rounded-3xl border border-white/10 bg-white/5 p-5">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between">
-            <div className="w-full lg:max-w-md">
-              <div className="text-xs font-extrabold text-white/70">Search</div>
-              <input
-                value={query}
-                onChange={(e) => {
-                  setQuery(e.target.value);
-                  setPage(1);
-                }}
-                placeholder="Search player name..."
-                className="mt-2 w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm font-semibold text-white outline-none placeholder:text-white/40 focus:border-white/25"
-              />
-            </div>
+      <PlayerSearchToolbar
+        query={query}
+        onChangeQuery={(next) => {
+          setQuery(next);
+          setPage(1);
+        }}
+        sort={sort}
+        sortOptions={sortOptions}
+        onChangeSort={(next) => {
+          setSort(next);
+          setPage(1);
+        }}
+        positionFilters={positionFilters}
+        position={position}
+        onChangePosition={(next) => {
+          setPosition(next);
+          setPage(1);
+        }}
+        hasDraftConfig={hasDraftConfig}
+        remainingBudget={remainingBudget}
+        onOpenCustomizeStats={() => setCustomizeStatsOpen(true)}
+      />
 
-            <div className="w-full lg:w-72">
-              <Dropdown<DraftSort>
-                label="Sort"
-                value={sort}
-                options={sortOptions}
-                onChange={(next) => {
-                  setSort(next);
-                  setPage(1);
-                }}
-              />
-            </div>
-          </div>
+      <ComparisonPanel
+        selectedA={selectedA}
+        selectedB={selectedB}
+        authed={authed}
+        onClearA={clearCompareA}
+        onClearB={clearCompareB}
+        onClearAll={clearCompare}
+        onOpenComparison={() => setComparisonOpen(true)}
+      />
 
-          <div className="mt-4 flex flex-wrap items-center gap-2">
-            {positionFilters.map((filterValue) => {
-              const active = position === filterValue;
-              return (
-                <button
-                  key={filterValue}
-                  onClick={() => {
-                    setPosition(filterValue);
-                    setPage(1);
-                  }}
-                  className={[
-                    "rounded-full px-3 py-1 text-xs font-extrabold transition",
-                    active
-                      ? "bg-white text-black"
-                      : "border border-white/10 bg-white/5 text-white/80 hover:bg-white/10",
-                  ].join(" ")}
-                >
-                  {filterValue}
-                </button>
-              );
-            })}
-
-            {hasDraftConfig && (
-              <div className="rounded-full border border-emerald-400/30 bg-emerald-500/10 px-3 py-1 text-xs font-black text-emerald-300">
-                Remaining Budget: ${remainingBudget}
-              </div>
-            )}
-
-            <button
-              type="button"
-              onClick={() => setCustomizeStatsOpen(true)}
-              className="ml-auto rounded-full border border-white/20 bg-white px-3 py-1 text-xs font-extrabold text-zinc-900 transition hover:bg-zinc-100"
-              title="Pick which 5 stats appear in the table"
-            >
-              Customize Stats
-            </button>
-          </div>
-        </section>
-      </FadeIn>
-
-      <FadeIn delayMs={120}>
-        <section className="rounded-2xl border border-fuchsia-500/55 bg-[#1b1228] p-4 shadow-[0_0_22px_rgba(168,85,247,0.22)]">
-          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex min-w-0 flex-1 flex-col gap-3 lg:flex-row lg:items-center">
-              <div className="rounded-xl bg-fuchsia-500/15 px-4 py-3 ring-1 ring-fuchsia-300/40 lg:min-w-[170px]">
-                <div className="text-sm font-black text-fuchsia-200">Compare</div>
-                <div className="mt-0.5 text-[11px] font-bold text-white/65">Select 2 players</div>
-              </div>
-
-              <div className="flex min-w-0 flex-1 flex-col items-stretch gap-2 sm:flex-row sm:items-center sm:justify-center">
-                <div className="min-w-0 w-full rounded-xl border border-emerald-400/50 bg-emerald-500/12 px-3 py-2 shadow-[0_0_16px_rgba(16,185,129,0.18)] sm:w-[300px]">
-                  {selectedA ? (
-                    <>
-                      <div className="flex items-center justify-between gap-2 text-xs text-white/80">
-                        <div className="flex min-w-0 items-center gap-2">
-                          <span className="rounded bg-emerald-500/25 px-1.5 py-0.5 font-black text-emerald-100">A</span>
-                          <span className="truncate font-black text-white">{selectedA.name}</span>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={clearCompareA}
-                          className="grid h-5 w-5 place-items-center rounded-full border border-white/20 bg-black/20 text-[10px] font-black text-white/80 transition hover:bg-white/15"
-                          aria-label="Remove player A from compare"
-                          title="Remove player A"
-                        >
-                          X
-                        </button>
-                      </div>
-                      <div className="mt-1 text-[11px] font-semibold text-white/70">
-                        {selectedA.positions.join("/")} - {selectedA.team} - ${selectedA.recommendedBid ?? "—"}
-                      </div>
-                      <div className="mt-1 text-[10px] text-white/55">
-                        {formatDraftStatSummary(selectedA)}
-                      </div>
-                    </>
-                  ) : (
-                    <div className="text-xs font-bold text-white/55">Select player A</div>
-                  )}
-                </div>
-
-                <div className="text-center text-xs font-black text-fuchsia-200 sm:px-1">VS</div>
-
-                <div className="min-w-0 w-full rounded-xl border border-emerald-400/50 bg-emerald-500/12 px-3 py-2 shadow-[0_0_16px_rgba(16,185,129,0.18)] sm:w-[300px]">
-                  {selectedB ? (
-                    <>
-                      <div className="flex items-center justify-between gap-2 text-xs text-white/80">
-                        <div className="flex min-w-0 items-center gap-2">
-                          <span className="rounded bg-emerald-500/25 px-1.5 py-0.5 font-black text-emerald-100">B</span>
-                          <span className="truncate font-black text-white">{selectedB.name}</span>
-                        </div>
-                        <button
-                          type="button"
-                          onClick={clearCompareB}
-                          className="grid h-5 w-5 place-items-center rounded-full border border-white/20 bg-black/20 text-[10px] font-black text-white/80 transition hover:bg-white/15"
-                          aria-label="Remove player B from compare"
-                          title="Remove player B"
-                        >
-                          X
-                        </button>
-                      </div>
-                      <div className="mt-1 text-[11px] font-semibold text-white/70">
-                        {selectedB.positions.join("/")} - {selectedB.team} - ${selectedB.recommendedBid ?? "—"}
-                      </div>
-                      <div className="mt-1 text-[10px] text-white/55">
-                        {formatDraftStatSummary(selectedB)}
-                      </div>
-                    </>
-                  ) : (
-                    <div className="text-xs font-bold text-white/55">Select player B</div>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-2 self-end lg:self-auto">
-              <button
-                type="button"
-                onClick={clearCompare}
-                disabled={!selectedA && !selectedB}
-                className="rounded-xl border border-white/15 bg-black/25 px-4 py-2 text-xs font-black text-white/80 transition hover:bg-white/10 disabled:opacity-40"
-              >
-                Clear
-              </button>
-              <button
-                type="button"
-                onClick={() => setComparisonOpen(true)}
-                disabled={!selectedA || !selectedB || !authed}
-                className="rounded-xl bg-fuchsia-600 px-4 py-2 text-xs font-black text-white transition hover:bg-fuchsia-500 disabled:opacity-40"
-                title={!authed ? "Sign in required" : "Open player comparison"}
-              >
-                Compare
-              </button>
-            </div>
-          </div>
-        </section>
-      </FadeIn>
-
-      <FadeIn delayMs={140}>
-        <section className="overflow-hidden rounded-3xl border border-white/10 bg-white/5">
-          <div className="grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_.9fr_1.3fr_1.1fr_.9fr] bg-black/40 px-4 py-3 text-xs font-extrabold text-white/60">
-            <div className="text-center">#</div>
-            <div>Player</div>
-            <div className="text-center">Pos</div>
-            <div className="text-center">Cost</div>
-            <div className="text-center">Team</div>
-            <div className="text-center">{statColumnLabels[0]}</div>
-            <div className="text-center">{statColumnLabels[1]}</div>
-            <div className="text-center">{statColumnLabels[2]}</div>
-            <div className="text-center">{statColumnLabels[3]}</div>
-            <div className="text-center">{statColumnLabels[4]}</div>
-            <div className="text-center">PPA-Value</div>
-            <div className="text-center">Action</div>
-            <div className="text-center">Compare</div>
-          </div>
-
-          <div className="bg-black/20">
-            {loading && (
-              <div className="p-4">
-                <Skeleton className="h-24" />
-              </div>
-            )}
-
-            {!loading && error && <div className="p-4 text-sm text-red-200">Failed to load players: {error}</div>}
-
-            {!loading && !error && players.length === 0 && (
-              <div className="p-4 text-sm text-white/70">No results. Try another search or filter.</div>
-            )}
-
-            {!loading &&
-              !error &&
-              players.map((player, idx) => {
-                const status = getPlayerDraftStatus(player.id, picks, teams);
-                // 픽이 있다면 그 팀의 accent 컬러를 가져온다 — 뱃지를 팀별 색으로 통일하기 위함.
-                const pickedByTeamIdx =
-                  status.kind !== "available"
-                    ? teams.findIndex((t) => t.id === status.teamId)
-                    : -1;
-                const pickedAccent =
-                  pickedByTeamIdx >= 0
-                    ? teamAccentClass(teams[pickedByTeamIdx], pickedByTeamIdx)
-                    : null;
-                const compareAActive = compareAId === player.id;
-                const compareBActive = compareBId === player.id;
-                const compareRole = compareAActive ? "A" : compareBActive ? "B" : null;
-                const compareActive = Boolean(compareRole);
-
-                return (
-                  <div
-                    key={player.id}
-                    className={[
-                      "grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_.9fr_1.3fr_1.1fr_.9fr] items-center px-4 py-3 text-sm text-white/85 transition tabular-nums",
-                      compareActive
-                        ? "relative z-[1] my-1 rounded-xl border border-emerald-400/75 bg-emerald-500/10 shadow-[0_0_18px_rgba(16,185,129,0.35)]"
-                        : "hover:bg-white/5",
-                    ].join(" ")}
-                  >
-                    <div className="text-center text-white/45">{(page - 1) * PAGE_SIZE + idx + 1}</div>
-
-                    <div className="min-w-0 flex items-center gap-1">
-                      {affectedPlayerIds.has(player.id) && (
-                        <span
-                          className="inline-block h-2 w-2 shrink-0 rounded-full bg-rose-500 animate-pulse"
-                          title="Recent update"
-                          aria-label="Recent update"
-                        />
-                      )}
-                      <button
-                        type="button"
-                        onClick={() => openPlayerInfo(player.id, player.playerType)}
-                        className="block w-full truncate rounded-md border border-transparent px-2 py-1 -mx-2 -my-1 text-left font-semibold text-white transition hover:border-white/35 hover:bg-white/5 hover:text-amber-200 focus-visible:border-white/45 focus-visible:bg-white/10 focus-visible:outline-none"
-                        title={player.name}
-                      >
-                        {player.name}
-                      </button>
-                      <button
-                        type="button"
-                        disabled={!authed}
-                        onClick={() => openNoteModal(player)}
-                        aria-label={notes[player.id] ? "Edit note" : "Add note"}
-                        title={
-                          !authed
-                            ? "Sign in required"
-                            : notes[player.id]
-                            ? "Edit note"
-                            : "Add note"
-                        }
-                        className={[
-                          "grid h-7 w-7 place-items-center rounded-md border transition",
-                          notes[player.id]
-                            ? "border-amber-400/50 bg-amber-500/15 text-amber-300 hover:bg-amber-500/25"
-                            : "border-white/10 bg-white/5 text-white/55 hover:bg-white/10 hover:text-white/80",
-                          !authed && "cursor-not-allowed opacity-40 hover:bg-white/5",
-                        ]
-                          .filter(Boolean)
-                          .join(" ")}
-                      >
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-4 w-4">
-                          <path d="M14 3v4a1 1 0 0 0 1 1h4" />
-                          <path d="M17 21H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h7l5 5v11a2 2 0 0 1-2 2Z" />
-                          <path d="M9 9h1" />
-                          <path d="M9 13h6" />
-                          <path d="M9 17h6" />
-                        </svg>
-                      </button>
-                    </div>
-
-                    <div className="text-center">
-                      <span className="inline-block rounded-lg bg-white/10 px-2 py-1 text-[11px] font-extrabold text-white/80">
-                        {player.positions[0]}
-                      </span>
-                    </div>
-
-                    <div className={`text-center ${draftCostClass(authed)}`}>${player.recommendedBid ?? "—"}</div>
-
-                    <div className="text-center">
-                      <span
-                        className={[
-                          "inline-flex items-center rounded-lg border px-2 py-1 text-[11px] font-extrabold",
-                          mlbTeamBadgeClass(player.team),
-                        ].join(" ")}
-                      >
-                        {player.team}
-                      </span>
-                    </div>
-
-                    {(isPitcherOnly(player) ? pitcherCols : batterCols).map((key, colIdx) => {
-                      const def = getStatDef(key);
-                      const value = def ? def.accessor(player) : null;
-                      const display = def ? def.format(value) : "—";
-                      // 짝수 컬럼은 옅은 화이트, 홀수 컬럼은 앰버 강조 — 시선 흐름 유지.
-                      const cellClass =
-                        colIdx % 2 === 0
-                          ? "text-center text-white/70"
-                          : "text-center font-semibold text-amber-300";
-                      return (
-                        <div key={key} className={cellClass}>
-                          {display}
-                        </div>
-                      );
-                    })}
-
-                    <div className={`text-center font-black ${ppaValueClass(player.ppaValue, { authed })}`}>
-                      {formatPpa(player.ppaValue)}
-                    </div>
-
-                    <div className="flex items-center justify-center gap-2">
-                      {status.kind !== "available" ? (
-                        // 픽된 선수의 뱃지는 픽한 팀의 accent 컬러로 통일. label 안에 Minor/Taxi 구분이 들어있음.
-                        <div className={`rounded-xl border px-3 py-2 text-xs font-black ${pickedAccent?.header ?? ""}`}>
-                          {status.label}
-                        </div>
-                      ) : authed ? (
-                        <>
-                          <button
-                            onClick={() => handleAddClick(player)}
-                            className="rounded-xl bg-emerald-500/15 px-3 py-2 text-xs font-black text-emerald-200 ring-1 ring-emerald-400/20 transition hover:bg-emerald-500/25"
-                          >
-                            Add
-                          </button>
-                          <button
-                            onClick={() => openTakenModal(player)}
-                            className="rounded-xl bg-rose-500/15 px-3 py-2 text-xs font-black text-rose-200 ring-1 ring-rose-400/20 transition hover:bg-rose-500/25"
-                          >
-                            Taken
-                          </button>
-                        </>
-                      ) : (
-                        <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-black text-white/40 blur-[1px]">
-                          Sign in required
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="flex items-center justify-center">
-                      <button
-                        type="button"
-                        disabled={!authed}
-                        onClick={() => handleCompareToggle(player.id)}
-                        className={[
-                          "relative h-6 w-14 rounded-full border transition",
-                          compareActive
-                            ? "border-emerald-300/70 bg-emerald-500/70 shadow-[0_0_12px_rgba(16,185,129,0.5)]"
-                            : "border-white/10 bg-white/5 hover:bg-white/10",
-                          !authed ? "opacity-40" : "",
-                        ].join(" ")}
-                        title={!authed ? "Sign in required" : compareRole ? `Selected ${compareRole}` : "Select for compare"}
-                      >
-                        <span
-                          className={[
-                            "absolute left-1 top-1 h-4 w-4 rounded-full bg-white transition-transform duration-200",
-                            compareActive ? "translate-x-8" : "translate-x-0",
-                          ].join(" ")}
-                        />
-                        {compareRole && (
-                          <span className="absolute left-2 top-1/2 -translate-y-1/2 text-[10px] font-black text-emerald-950">
-                            {compareRole}
-                          </span>
-                        )}
-                      </button>
-                    </div>
-                  </div>
-                );
-              })}
-          </div>
-
-          <div className="border-t border-white/10 px-4 py-3 text-xs text-white/45">
-            Players and draft picks are loaded from backend APIs.
-          </div>
-        </section>
-
-        <Pagination page={page} totalPages={totalPages} onChange={setPage} />
-      </FadeIn>
+      <PlayerListTable
+        players={players}
+        picks={picks}
+        teams={teams}
+        page={page}
+        pageSize={PAGE_SIZE}
+        totalPages={totalPages}
+        onChangePage={setPage}
+        statColumnLabels={statColumnLabels}
+        batterCols={batterCols}
+        pitcherCols={pitcherCols}
+        loading={loading}
+        error={error}
+        authed={authed}
+        notes={notes}
+        affectedPlayerIds={affectedPlayerIds}
+        compareAId={compareAId}
+        compareBId={compareBId}
+        onAddPick={handleAddClick}
+        onTakenPick={openTakenModal}
+        onOpenNote={openNoteModal}
+        onOpenPlayerInfo={openPlayerInfo}
+        onToggleCompare={handleCompareToggle}
+      />
 
       {addTarget && (
         <AddBidModal
@@ -1749,119 +1126,28 @@ export default function DraftPage() {
       )}
 
       {saveModalOpen && (
-        <div className="fixed inset-0 z-[80] grid place-items-center p-4">
-          <button
-            type="button"
-            aria-label="Close save dialog"
-            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
-            onClick={closeSaveModal}
-          />
-          <div className="relative w-full max-w-md rounded-3xl border border-white/15 bg-[#0c1220] p-6 shadow-2xl">
-            <div className="text-lg font-black text-white">
-              {isLoadedMode ? "Save Changes" : "Save Draft"}
-            </div>
-            <div className="mt-1 text-xs text-white/55">
-              Enter a session name (up to 3 saved sessions)
-            </div>
-
-            <input
-              type="text"
-              value={saveNameInput}
-              onChange={(e) => {
-                setSaveNameInput(e.target.value);
-                if (saveError) setSaveError(null);
-              }}
-              placeholder="e.g. 2026 Black Sluggers"
-              className="mt-4 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm font-semibold text-white outline-none placeholder:text-white/40 focus:border-white/25"
-              autoFocus
-            />
-
-            {saveError && (
-              <div className="mt-2 text-xs font-bold text-rose-300">{saveError}</div>
-            )}
-
-            <div className="mt-5 flex gap-2">
-              <button
-                type="button"
-                onClick={closeSaveModal}
-                disabled={saving}
-                className="flex-1 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-black text-white/80 transition hover:bg-white/10 disabled:opacity-50"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleSaveConfirm}
-                disabled={saving}
-                className="flex-1 rounded-2xl bg-emerald-500 px-4 py-3 text-sm font-black text-white transition hover:bg-emerald-400 disabled:opacity-50"
-              >
-                {saving ? "Saving..." : "Save"}
-              </button>
-            </div>
-          </div>
-        </div>
+        <SaveSessionModal
+          isLoadedMode={isLoadedMode}
+          nameInput={saveNameInput}
+          onChangeName={(next) => {
+            setSaveNameInput(next);
+            if (saveError) setSaveError(null);
+          }}
+          error={saveError}
+          saving={saving}
+          onCancel={closeSaveModal}
+          onConfirm={handleSaveConfirm}
+        />
       )}
 
       {importModalOpen && (
-        <div className="fixed inset-0 z-[80] grid place-items-center p-4">
-          <button
-            type="button"
-            aria-label="Close import dialog"
-            className="absolute inset-0 bg-black/70 backdrop-blur-sm"
-            onClick={closeImportModal}
-          />
-          <div className="relative w-full max-w-lg rounded-3xl border border-white/15 bg-[#0c1220] p-6 shadow-2xl">
-            <div className="flex items-center justify-between">
-              <div className="text-lg font-black text-white">Saved Sessions</div>
-              <button
-                type="button"
-                onClick={closeImportModal}
-                className="grid h-8 w-8 place-items-center rounded-full border border-white/15 bg-black/25 text-sm font-black text-white/80 hover:bg-white/10"
-                aria-label="Close"
-              >
-                X
-              </button>
-            </div>
-
-            <div className="mt-4 max-h-[60vh] overflow-y-auto rounded-2xl border border-white/10 bg-black/20">
-              {sessionListLoading && (
-                <div className="p-4 text-sm text-white/65">Loading sessions...</div>
-              )}
-
-              {!sessionListLoading && sessionList.length === 0 && (
-                <div className="p-4 text-sm text-white/65">No saved sessions yet.</div>
-              )}
-
-              {!sessionListLoading &&
-                sessionList.map((s) => (
-                  <div
-                    key={s.id}
-                    className="flex items-center gap-3 border-b border-white/5 px-4 py-3 last:border-b-0 hover:bg-white/5"
-                  >
-                    <button
-                      type="button"
-                      onClick={() => handleSessionPick(s.id)}
-                      className="flex-1 text-left"
-                    >
-                      <div className="text-sm font-black text-white">{s.name}</div>
-                      <div className="mt-0.5 text-xs text-white/55">
-                        {s.createdAt.slice(0, 10)}
-                      </div>
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => handleSessionDelete(s.id)}
-                      aria-label="Delete session"
-                      title="Delete session"
-                      className="grid h-9 w-9 place-items-center rounded-xl border border-rose-400/30 bg-rose-500/10 text-rose-200 transition hover:bg-rose-500/20"
-                    >
-                      🗑
-                    </button>
-                  </div>
-                ))}
-            </div>
-          </div>
-        </div>
+        <ImportSessionsModal
+          sessions={sessionList}
+          loading={sessionListLoading}
+          onClose={closeImportModal}
+          onPick={handleSessionPick}
+          onDelete={handleSessionDelete}
+        />
       )}
 
       <Modal


### PR DESCRIPTION
…ponents + add undo/redo keyboard shortcuts

## What
<!-- What did you do? -->
- Split `DraftPage.tsx` (1884 → 1160 lines, -38%) into focused modules:
  - `draftHelpers.ts` — pure helpers, constants, response types
  - `useDraftSessionLoader.ts` — session bootstrap + notes fetch hook
  - 6 sub-components: `DraftHeaderBar`, `PlayerSearchToolbar`, `ComparisonPanel`,
    `PlayerListTable`, `SaveSessionModal`, `ImportSessionsModal`
- Added `useUndoKeyboardShortcuts` hook — Ctrl/Cmd+Z = undo,
  Ctrl+Y or Ctrl/Cmd+Shift+Z = redo. Skipped inside text inputs so the
  browser's native undo still works there.

## Why
<!-- Why did you do it? -->
- DraftPage was hard to navigate at ~1900 lines; logical sections were
  buried in long JSX
- Same undo stack existed already — keyboard shortcuts make it discoverable
- Behavior preserved 100%: no API contract changes, all state stays in
  DraftPage, sub-components are presentational

## Related Issue
<!-- e.g. #123 -->
#112 