### PR TITLE
header Start Draft + New button + custom roster sizing

### DIFF
--- a/fe/src/features/draft/components/DraftHeaderBar.tsx
+++ b/fe/src/features/draft/components/DraftHeaderBar.tsx
@@ -18,8 +18,14 @@ type Props = {
   onUndo: () => void;
   onRedo: () => void;
   onDiscard: () => void;
+  // New = wipe current local state and start a fresh setup. The parent
+  // decides whether to prompt for a save first.
+  onNew: () => void;
   onSave: () => void;
   onImport: () => void;
+  // Start Draft = open the setup modal (or login modal if not authed).
+  // Only rendered when there is no draft in progress.
+  onStartDraft: () => void;
 };
 
 export default function DraftHeaderBar({
@@ -35,8 +41,10 @@ export default function DraftHeaderBar({
   onUndo,
   onRedo,
   onDiscard,
+  onNew,
   onSave,
   onImport,
+  onStartDraft,
 }: Props) {
   return (
     <FadeIn>
@@ -102,6 +110,16 @@ export default function DraftHeaderBar({
               Discard
             </button>
           )}
+          {hasDraftConfig && (
+            <button
+              type="button"
+              onClick={onNew}
+              className="rounded-2xl border border-sky-400/30 bg-sky-500/10 px-4 py-3 text-sm font-black text-sky-200 transition hover:bg-sky-500/20"
+              title="Start a fresh draft session (re-configure budget / teams / roster)"
+            >
+              New
+            </button>
+          )}
           {authed && (
             <>
               {hasDraftConfig && (
@@ -123,6 +141,21 @@ export default function DraftHeaderBar({
                 Import
               </button>
             </>
+          )}
+
+          {!hasDraftConfig && (
+            <button
+              type="button"
+              onClick={onStartDraft}
+              className="rounded-2xl bg-white px-4 py-3 text-sm font-black text-black transition hover:bg-zinc-100"
+              title={
+                authed
+                  ? "Configure budget / teams and start a live draft"
+                  : "Sign in to start a draft"
+              }
+            >
+              Start Draft
+            </button>
           )}
 
           {hasDraftConfig && (

--- a/fe/src/features/home/DraftSetupCard.tsx
+++ b/fe/src/features/home/DraftSetupCard.tsx
@@ -63,8 +63,10 @@ const POSITION_ORDER: RosterSlotPosition[] = [
   "C", "1B", "2B", "3B", "SS", "OF", "UTIL", "SP", "RP", "BENCH",
 ];
 
-// 사용자가 슬롯 합계를 정확히 이 값과 맞춰야 Start Draft 가 활성화된다.
-const TARGET_ROSTER_SIZE = sumRosterSlots(DEFAULT_ROSTER_SLOTS);
+// AL / NL 은 표준 16 슬롯으로 고정 (사용자가 16 안에서 배분만 가능).
+// Custom 은 완전 자유 — 최소 1 명만 채우면 OK.
+const TARGET_ROSTER_SIZE = sumRosterSlots(DEFAULT_ROSTER_SLOTS); // = 16
+const MIN_ROSTER_SIZE = 1;
 
 const POSITION_LABEL: Record<RosterSlotPosition, string> = {
   C: "C",
@@ -126,9 +128,16 @@ export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {
     }));
   };
 
-  // 슬롯 합계가 정확히 TARGET_ROSTER_SIZE 와 일치해야 시작 가능.
+  // 리그별 검증:
+  //   AL / NL → 합계 정확히 TARGET_ROSTER_SIZE (16)
+  //   custom  → 합계 ≥ MIN_ROSTER_SIZE (1)
+  const isCustomLeague = leagueType === "custom";
   const rosterDelta = rosterPlayers - TARGET_ROSTER_SIZE;
-  const canStart = rosterDelta === 0;
+  const canStart = isCustomLeague
+    ? rosterPlayers >= MIN_ROSTER_SIZE
+    : rosterDelta === 0;
+
+  const resetRosterSlots = () => setRosterSlots(DEFAULT_ROSTER_SLOTS);
 
   const onStartDraft = () => {
     if (!canStart) return;
@@ -279,14 +288,28 @@ export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {
         </div>
 
         <div className="rounded-2xl border border-white/10 bg-black/20 p-3">
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-2">
             <div className="text-xs font-extrabold text-white/70">Roster slots by position</div>
-            <div className="text-xs font-black">
-              <span className="text-white/70">Total: </span>
-              <span className={canStart ? "text-emerald-300" : "text-rose-300"}>
-                {rosterPlayers}
-              </span>
-              <span className="text-white/40"> / {TARGET_ROSTER_SIZE}</span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={resetRosterSlots}
+                className="rounded-lg border border-white/15 bg-black/30 px-2 py-1 text-[11px] font-black text-white/75 transition hover:bg-white/10"
+                title="Reset roster slots to the default 16-player layout"
+              >
+                Reset
+              </button>
+              <div className="text-xs font-black">
+                <span className="text-white/70">Total: </span>
+                <span className={canStart ? "text-emerald-300" : "text-rose-300"}>
+                  {rosterPlayers}
+                </span>
+                {isCustomLeague ? (
+                  <span className="text-white/40">{rosterPlayers === 1 ? " player" : " players"}</span>
+                ) : (
+                  <span className="text-white/40"> / {TARGET_ROSTER_SIZE}</span>
+                )}
+              </div>
             </div>
           </div>
 
@@ -334,9 +357,11 @@ export default function DraftSetupCard({ onSubmit, embedded = false }: Props = {
 
         {!canStart && (
           <div className="text-center text-xs text-rose-300">
-            {rosterDelta < 0
-              ? `Add ${-rosterDelta} more roster slot${-rosterDelta === 1 ? "" : "s"} to reach ${TARGET_ROSTER_SIZE} players.`
-              : `Remove ${rosterDelta} roster slot${rosterDelta === 1 ? "" : "s"} to fit ${TARGET_ROSTER_SIZE} players.`}
+            {isCustomLeague
+              ? "Add at least one roster slot to start the draft."
+              : rosterDelta < 0
+                ? `Add ${-rosterDelta} more roster slot${-rosterDelta === 1 ? "" : "s"} to reach ${TARGET_ROSTER_SIZE} players.`
+                : `Remove ${rosterDelta} roster slot${rosterDelta === 1 ? "" : "s"} to fit ${TARGET_ROSTER_SIZE} players.`}
           </div>
         )}
 

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -116,6 +116,10 @@ export default function DraftPage() {
   const [setupModalOpen, setSetupModalOpen] = useState(false);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
 
+  // "New" → "Save first?" Yes 경로에서 Save 가 끝난 직후 setup 모달을
+  // 자동으로 열기 위한 플래그. Save 모달이 cancel 되면 클리어.
+  const [postSaveAction, setPostSaveAction] = useState<"setup" | null>(null);
+
   // Toast queue. id 는 monotonic counter 로 부여한다.
   const toastIdRef = useRef(0);
   const [toasts, setToasts] = useState<ToastMessage[]>([]);
@@ -440,6 +444,49 @@ export default function DraftPage() {
       setSetupModalOpen(true);
     } else {
       setLoginModalOpen(true);
+    }
+  };
+
+  // 모든 로컬 상태 / sessionStorage 를 초기화해 "갓 들어온" 상태로 만든 다음
+  // setup 모달을 띄움. 로드 모드였다면 URL 도 /draft 로 바꿔서 사이드 효과 차단.
+  const resetToFreshSetup = () => {
+    try {
+      removeUnsavedDraftStorage();
+    } catch {
+      // 무시
+    }
+    if (isLoadedMode) {
+      navigate("/draft", { replace: true });
+    }
+    setConfig(DEFAULT_DRAFT_CONFIG);
+    setTeams(buildTeamsFromConfig(DEFAULT_DRAFT_CONFIG));
+    resetPicks([]);
+    setNotes({});
+    setHasDraftConfig(false);
+    setSessionName(null);
+    setSetupModalOpen(true);
+  };
+
+  // New 버튼 — 현재 드래프트를 정리하고 새로 시작하는 setup 모달을 띄움.
+  //   - 로드된 세션 (isLoadedMode): 이미 DB 에 저장돼 있으니 즉시 setup.
+  //   - 미저장 드래프트: 저장 여부를 묻는 confirm 후 Yes/No 분기.
+  const handleNewDraft = () => {
+    if (isLoadedMode) {
+      resetToFreshSetup();
+      return;
+    }
+
+    const saveFirst = window.confirm(
+      "Save the current draft before starting a new one?\n\n" +
+        "OK → save first, then open new setup\n" +
+        "Cancel → discard current draft and open new setup"
+    );
+
+    if (saveFirst) {
+      setPostSaveAction("setup");
+      openSaveModal();
+    } else {
+      resetToFreshSetup();
     }
   };
 
@@ -823,6 +870,8 @@ export default function DraftPage() {
   const closeSaveModal = () => {
     setSaveModalOpen(false);
     setSaveError(null);
+    // 사용자가 Save 를 취소하면 chained post-save action 도 함께 폐기.
+    setPostSaveAction(null);
   };
 
   const handleSaveConfirm = () => {
@@ -843,7 +892,14 @@ export default function DraftPage() {
       )
         .then((data) => {
           setSessionName(data.name);
+          // closeSaveModal 은 postSaveAction 도 클리어하므로, chain 동작이
+          // 예약돼 있었다면 그 사실을 먼저 캡처한 뒤 닫는다.
+          const chained = postSaveAction;
           closeSaveModal();
+          if (chained === "setup") {
+            // 저장된 세션을 그대로 두고 새 setup 으로 이동.
+            resetToFreshSetup();
+          }
         })
         .catch((err: unknown) => {
           console.error(err);
@@ -881,7 +937,16 @@ export default function DraftPage() {
         }
         setSaving(false);
         setSaveModalOpen(false);
-        navigate(`/draft/${data.id}`, { replace: true });
+
+        if (postSaveAction === "setup") {
+          // "New" 흐름에서 Yes-save 를 거친 경우 — 새로 만든 세션 URL 로
+          // 이동하지 않고, 곧바로 새 setup 모달을 띄운다. (세션은 DB 에
+          // 저장돼 있으므로 추후 Import 에서 다시 열 수 있다.)
+          setPostSaveAction(null);
+          resetToFreshSetup();
+        } else {
+          navigate(`/draft/${data.id}`, { replace: true });
+        }
       })
       .catch((err: unknown) => {
         setSaving(false);
@@ -964,8 +1029,10 @@ export default function DraftPage() {
         onUndo={undoPicks}
         onRedo={redoPicks}
         onDiscard={handleDiscardDraft}
+        onNew={handleNewDraft}
         onSave={openSaveModal}
         onImport={openImportModal}
+        onStartDraft={openStartDraft}
       />
 
       <FadeIn delayMs={60}>
@@ -991,16 +1058,9 @@ export default function DraftPage() {
               </div>
               <div className="mt-2 text-sm text-white/60">
                 {authed
-                  ? "Set up your league to start the live draft board."
-                  : "Sign in and set up your league to start the live draft board."}
+                  ? "Use the Start Draft button above to set up your league."
+                  : "Sign in and use the Start Draft button above to set up your league."}
               </div>
-              <button
-                type="button"
-                onClick={openStartDraft}
-                className="mt-6 inline-flex items-center justify-center rounded-2xl bg-white px-8 py-4 text-base font-black text-black transition hover:-translate-y-px hover:bg-white/90 active:translate-y-0"
-              >
-                Start Your Draft
-              </button>
             </section>
           )}
         </div>


### PR DESCRIPTION

## What
<!-- What did you do? -->
- **Start Draft** moved from the "Ready to draft?" placeholder into the
  header (next to Import). Placeholder keeps the text only.
- **New** button added next to Discard while a draft is in progress.
  - Loaded session → opens setup modal immediately (DB session intact)
  - Unsaved draft → prompts to save first; Yes saves then opens setup,
    No discards then opens setup
- **Roster size**: AL/NL stay locked at 16 (existing behavior). Custom
  league is now fully free (min 1, no max).
- **Reset** button next to Roster slots — restores the default 16-slot layout.
- 
## Why
<!-- Why did you do it? -->
- Start Draft was buried in the empty state; users couldn't see it once
  drafting and wanted a way to start over
- Discard only clears picks; New is the missing "fresh setup" action
- Fixed-16 totals contradicted the Custom league label

## Related Issue
<!-- e.g. #123 -->
#114 