### PR TITLE
disable pick buttons before Start; safer New confirm; reorder header

### DIFF
--- a/fe/src/features/draft/components/DraftHeaderBar.tsx
+++ b/fe/src/features/draft/components/DraftHeaderBar.tsx
@@ -99,6 +99,16 @@ export default function DraftHeaderBar({
           {hasDraftConfig && (
             <button
               type="button"
+              onClick={onNew}
+              className="rounded-2xl border border-sky-400/30 bg-sky-500/10 px-4 py-3 text-sm font-black text-sky-200 transition hover:bg-sky-500/20"
+              title="Start a fresh draft session (re-configure budget / teams / roster)"
+            >
+              New
+            </button>
+          )}
+          {hasDraftConfig && (
+            <button
+              type="button"
               onClick={onDiscard}
               className="rounded-2xl border border-rose-400/30 bg-rose-500/10 px-4 py-3 text-sm font-black text-rose-200 transition hover:bg-rose-500/20"
               title={
@@ -108,16 +118,6 @@ export default function DraftHeaderBar({
               }
             >
               Discard
-            </button>
-          )}
-          {hasDraftConfig && (
-            <button
-              type="button"
-              onClick={onNew}
-              className="rounded-2xl border border-sky-400/30 bg-sky-500/10 px-4 py-3 text-sm font-black text-sky-200 transition hover:bg-sky-500/20"
-              title="Start a fresh draft session (re-configure budget / teams / roster)"
-            >
-              New
             </button>
           )}
           {authed && (

--- a/fe/src/features/draft/components/NewDraftConfirmModal.tsx
+++ b/fe/src/features/draft/components/NewDraftConfirmModal.tsx
@@ -1,0 +1,68 @@
+// 3-button confirmation dialog used when the user clicks "New" with an
+// unsaved draft in progress. The choices are intentionally distinct so
+// Cancel = abort (default safe action) and the destructive path
+// ("Discard current") needs an explicit click.
+
+import Modal from "../../../components/ui/Modal";
+
+type Props = {
+  onSaveFirst: () => void;
+  onDiscardCurrent: () => void;
+  onCancel: () => void;
+};
+
+export default function NewDraftConfirmModal({
+  onSaveFirst,
+  onDiscardCurrent,
+  onCancel,
+}: Props) {
+  const footer = (
+    <>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="rounded-xl border border-white/15 bg-black/30 px-4 py-2 text-sm font-black text-white/80 transition hover:bg-white/10"
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        onClick={onDiscardCurrent}
+        className="rounded-xl border border-rose-400/30 bg-rose-500/15 px-4 py-2 text-sm font-black text-rose-200 transition hover:bg-rose-500/25"
+      >
+        Discard current
+      </button>
+      <button
+        type="button"
+        onClick={onSaveFirst}
+        className="rounded-xl border border-emerald-400/30 bg-emerald-500/15 px-4 py-2 text-sm font-black text-emerald-200 transition hover:bg-emerald-500/25"
+      >
+        Save first
+      </button>
+    </>
+  );
+
+  return (
+    <Modal open={true} title="Start a new draft?" onClose={onCancel} footer={footer}>
+      <p className="text-sm text-white/75">
+        You have an unsaved draft in progress. What would you like to do?
+      </p>
+      <ul className="mt-3 space-y-1 text-xs text-white/60">
+        <li>
+          <span className="font-black text-emerald-300">Save first</span>
+          {" "}— save the current draft as a new session, then open the setup
+          screen.
+        </li>
+        <li>
+          <span className="font-black text-rose-300">Discard current</span>
+          {" "}— wipe the current local draft and open the setup screen.
+          This cannot be undone.
+        </li>
+        <li>
+          <span className="font-black text-white/80">Cancel</span>
+          {" "}— close this dialog and return to your draft unchanged.
+        </li>
+      </ul>
+    </Modal>
+  );
+}

--- a/fe/src/features/draft/components/PlayerListTable.tsx
+++ b/fe/src/features/draft/components/PlayerListTable.tsx
@@ -37,6 +37,7 @@ type Props = {
   loading: boolean;
   error: string | null;
   authed: boolean;
+  hasDraftConfig: boolean;
   notes: Record<string, string>;
   affectedPlayerIds: Set<string>;
   compareAId: string | null;
@@ -62,6 +63,7 @@ export default function PlayerListTable({
   loading,
   error,
   authed,
+  hasDraftConfig,
   notes,
   affectedPlayerIds,
   compareAId,
@@ -228,25 +230,31 @@ export default function PlayerListTable({
                       <div className={`rounded-xl border px-3 py-2 text-xs font-black ${pickedAccent?.header ?? ""}`}>
                         {status.label}
                       </div>
-                    ) : authed ? (
+                    ) : !authed ? (
+                      <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-black text-white/40 blur-[1px]">
+                        Sign in required
+                      </div>
+                    ) : (
                       <>
                         <button
+                          type="button"
+                          disabled={!hasDraftConfig}
                           onClick={() => onAddPick(player)}
-                          className="rounded-xl bg-emerald-500/15 px-3 py-2 text-xs font-black text-emerald-200 ring-1 ring-emerald-400/20 transition hover:bg-emerald-500/25"
+                          title={hasDraftConfig ? "Add to my team" : "Start a draft to make picks"}
+                          className="rounded-xl bg-emerald-500/15 px-3 py-2 text-xs font-black text-emerald-200 ring-1 ring-emerald-400/20 transition hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-emerald-500/15"
                         >
                           Add
                         </button>
                         <button
+                          type="button"
+                          disabled={!hasDraftConfig}
                           onClick={() => onTakenPick(player)}
-                          className="rounded-xl bg-rose-500/15 px-3 py-2 text-xs font-black text-rose-200 ring-1 ring-rose-400/20 transition hover:bg-rose-500/25"
+                          title={hasDraftConfig ? "Mark as drafted by another team" : "Start a draft to make picks"}
+                          className="rounded-xl bg-rose-500/15 px-3 py-2 text-xs font-black text-rose-200 ring-1 ring-rose-400/20 transition hover:bg-rose-500/25 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-rose-500/15"
                         >
                           Taken
                         </button>
                       </>
-                    ) : (
-                      <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2 text-xs font-black text-white/40 blur-[1px]">
-                        Sign in required
-                      </div>
                     )}
                   </div>
 

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -74,6 +74,7 @@ import PlayerComparisonModal from "../features/draft/components/PlayerComparison
 import PlayerNotePopover from "../features/draft/components/PlayerNotePopover";
 import CustomizeStatsModal from "../features/draft/components/CustomizeStatsModal";
 import SaveSessionModal from "../features/draft/components/SaveSessionModal";
+import NewDraftConfirmModal from "../features/draft/components/NewDraftConfirmModal";
 import ImportSessionsModal from "../features/draft/components/ImportSessionsModal";
 import PlayerListTable from "../features/draft/components/PlayerListTable";
 import DraftHeaderBar from "../features/draft/components/DraftHeaderBar";
@@ -119,6 +120,9 @@ export default function DraftPage() {
   // "New" → "Save first?" Yes 경로에서 Save 가 끝난 직후 setup 모달을
   // 자동으로 열기 위한 플래그. Save 모달이 cancel 되면 클리어.
   const [postSaveAction, setPostSaveAction] = useState<"setup" | null>(null);
+
+  // "New" 클릭 시 띄우는 3-버튼 확인 모달 — 미저장 상태에서만 사용.
+  const [newConfirmOpen, setNewConfirmOpen] = useState(false);
 
   // Toast queue. id 는 monotonic counter 로 부여한다.
   const toastIdRef = useRef(0);
@@ -469,25 +473,30 @@ export default function DraftPage() {
 
   // New 버튼 — 현재 드래프트를 정리하고 새로 시작하는 setup 모달을 띄움.
   //   - 로드된 세션 (isLoadedMode): 이미 DB 에 저장돼 있으니 즉시 setup.
-  //   - 미저장 드래프트: 저장 여부를 묻는 confirm 후 Yes/No 분기.
+  //   - 미저장 드래프트: 3-버튼 확인 모달 (Save first / Discard current / Cancel)
+  //     로 분기. Cancel 은 진짜 abort — 드래프트 상태 변경 없음.
   const handleNewDraft = () => {
     if (isLoadedMode) {
       resetToFreshSetup();
       return;
     }
+    setNewConfirmOpen(true);
+  };
 
-    const saveFirst = window.confirm(
-      "Save the current draft before starting a new one?\n\n" +
-        "OK → save first, then open new setup\n" +
-        "Cancel → discard current draft and open new setup"
-    );
+  const handleNewConfirmSaveFirst = () => {
+    setNewConfirmOpen(false);
+    setPostSaveAction("setup");
+    openSaveModal();
+  };
 
-    if (saveFirst) {
-      setPostSaveAction("setup");
-      openSaveModal();
-    } else {
-      resetToFreshSetup();
-    }
+  const handleNewConfirmDiscard = () => {
+    setNewConfirmOpen(false);
+    resetToFreshSetup();
+  };
+
+  const handleNewConfirmCancel = () => {
+    // 진짜 cancel — 아무 상태도 변경하지 않음.
+    setNewConfirmOpen(false);
   };
 
   // 진행 중인 미저장 draft 폐기 — sessionStorage 비우고 player browser 상태로 복귀.
@@ -1113,6 +1122,7 @@ export default function DraftPage() {
         loading={loading}
         error={error}
         authed={authed}
+        hasDraftConfig={hasDraftConfig}
         notes={notes}
         affectedPlayerIds={affectedPlayerIds}
         compareAId={compareAId}
@@ -1207,6 +1217,14 @@ export default function DraftPage() {
           onClose={closeImportModal}
           onPick={handleSessionPick}
           onDelete={handleSessionDelete}
+        />
+      )}
+
+      {newConfirmOpen && (
+        <NewDraftConfirmModal
+          onSaveFirst={handleNewConfirmSaveFirst}
+          onDiscardCurrent={handleNewConfirmDiscard}
+          onCancel={handleNewConfirmCancel}
         />
       )}
 


### PR DESCRIPTION


## What
<!-- What did you do? -->
- Add / Taken buttons are now disabled (greyed out + tooltip) when no draft
  has been started — previously they fired and registered phantom picks.
- Replaced the `window.confirm` for **New** with a 3-button modal:
  - **Save first** → save, then open setup
  - **Discard current** → wipe, then open setup
  - **Cancel** → true abort (the old "Cancel" silently discarded)
- Header button order changed to **New → Discard → Save** (was Discard → New → Save).

## Why
<!-- Why did you do it? -->
- The biggest hazard was the old Cancel button silently wiping the user's
  in-progress draft. Misclick-friendly destructive default is unsafe.
- Add/Taken without a draft caused confusing state where picks appeared
  to be recorded but had no host session.
- New is the entry to a fresh draft, so giving it the leading slot makes
  the action sequence read naturally.

## Related Issue
<!-- e.g. #123 -->
#116 