### PR TITLE
use active draft session, show empty state when none

### DIFF
--- a/fe/src/features/draft/draftHelpers.ts
+++ b/fe/src/features/draft/draftHelpers.ts
@@ -127,6 +127,34 @@ export function removeUnsavedDraftStorage() {
   localStorage.removeItem(UNSAVED_DRAFT_KEY);
 }
 
+// "현재 드래프트 페이지에서 보고 있는 세션 id" 를 페이지 간에 공유.
+// My Team 페이지가 이를 우선 source-of-truth 로 써서 stale URL ?sessionId
+// 때문에 옛 세션의 픽을 보여주는 문제를 막는다.
+//   - 로드 모드 (/draft/:id) 진입 → setActiveDraftSessionId(id)
+//   - 미저장 모드 / discard 후 빈 상태 / "New" 후 reset → setActiveDraftSessionId(null)
+//   - 미저장을 저장(POST) 한 직후 → setActiveDraftSessionId(newId)
+const ACTIVE_DRAFT_SESSION_KEY = "ppadun_active_draft_session_id";
+
+export function setActiveDraftSessionId(id: number | null) {
+  try {
+    if (id === null) sessionStorage.removeItem(ACTIVE_DRAFT_SESSION_KEY);
+    else sessionStorage.setItem(ACTIVE_DRAFT_SESSION_KEY, String(id));
+  } catch {
+    // quota / privacy mode — 무시
+  }
+}
+
+export function getActiveDraftSessionId(): number | null {
+  try {
+    const raw = sessionStorage.getItem(ACTIVE_DRAFT_SESSION_KEY);
+    if (!raw) return null;
+    const n = Number(raw);
+    return Number.isFinite(n) && n > 0 ? n : null;
+  } catch {
+    return null;
+  }
+}
+
 export function readUnsavedDraftStorage(): string | null {
   const current = sessionStorage.getItem(UNSAVED_DRAFT_KEY);
   if (current) return current;

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -60,6 +60,7 @@ import {
   primaryRateSortValue,
   productionSortValue,
   removeUnsavedDraftStorage,
+  setActiveDraftSessionId,
   speedSortValue,
   type DraftPlayersResponse,
   type DraftPlayerValuesResponse,
@@ -547,6 +548,17 @@ export default function DraftPage() {
     setNotes,
     resetPicks,
   });
+
+  // My Team 페이지가 "현재 활성 드래프트 세션" 을 알도록 sessionStorage 에 mirror.
+  // 로드 모드 → 그 sessionId, 미저장(또는 fresh) → null.
+  // → My Team 페이지가 옛 URL ?sessionId 로 잘못된 세션을 보여주는 문제 차단.
+  useEffect(() => {
+    if (isLoadedMode && sessionId !== null) {
+      setActiveDraftSessionId(sessionId);
+    } else {
+      setActiveDraftSessionId(null);
+    }
+  }, [isLoadedMode, sessionId]);
 
   // 미저장 모드에서 picks/notes 가 바뀔 때마다 sessionStorage 에도 sync — 페이지 이동/새로고침 보호.
   useEffect(() => {

--- a/fe/src/pages/MyTeamPage.tsx
+++ b/fe/src/pages/MyTeamPage.tsx
@@ -17,6 +17,7 @@ import {
   sortMyTeam,
 } from "../features/myteam/utils";
 import { mlbTeamBadgeClass } from "../features/draft/utils";
+import { getActiveDraftSessionId } from "../features/draft/draftHelpers";
 import { formatPpa, ppaValueClass } from "../utils/playerValue";
 import { apiGetAuth } from "../lib/api";
 import PlayerInfoModal from "../features/players/components/PlayerInfoModal";
@@ -98,9 +99,11 @@ export default function MyTeamPage() {
   const [profilePlayerType, setProfilePlayerType] = useState<"batter" | "pitcher">("batter");
 
   // ── 1단계: 세션 목록 조회 + sessionId 결정 ──
-  // - URL ?sessionId 가 사용자 소유 세션 중 하나면 그 값을 사용 (새로고침/공유 케이스)
-  // - 아니면 last_opened_at DESC 기준 첫 번째 세션을 default 로 사용
-  // - 0개면 sessionId 는 null 로 두고 빈 상태 UI 표시
+  // 우선순위:
+  //   1) activeDraftSessionId (sessionStorage) — 사용자가 지금 Draft 페이지에서
+  //      보고 있는 세션. "My Team 은 현재 드래프트와 연동" 시맨틱.
+  //   2) URL ?sessionId — 직접 링크 / 북마크 케이스 (소유 세션일 때만).
+  //   3) 그 외 → "활성 드래프트 없음" 빈 상태 (자동으로 옛 세션 불러오지 않음).
   useEffect(() => {
     const controller = new AbortController();
 
@@ -119,17 +122,25 @@ export default function MyTeamPage() {
           return;
         }
 
+        // activeDraftSessionId 가 유효한 소유 세션이면 최우선.
+        const activeId = getActiveDraftSessionId();
+        if (activeId !== null && items.some((s) => s.id === activeId)) {
+          setSessionId(activeId);
+          const next = new URLSearchParams(searchParams);
+          next.set("sessionId", String(activeId));
+          setSearchParams(next, { replace: true });
+          return;
+        }
+
+        // 활성 드래프트가 없으면 URL 만 신뢰. 옛 stale URL 이라도 그 값이
+        // 소유 세션이면 그대로 두고 (북마크/공유 시나리오), 아니면 빈 상태.
         const urlIdNum = urlSessionIdRaw ? Number(urlSessionIdRaw) : NaN;
         const urlIsValid =
           Number.isFinite(urlIdNum) && items.some((s) => s.id === urlIdNum);
-        const resolvedId = urlIsValid ? urlIdNum : items[0].id;
-        setSessionId(resolvedId);
-
-        // URL 동기화 (잘못된/비어있는 sessionId → 가장 최근 세션으로 교체)
-        if (!urlIsValid || urlIdNum !== resolvedId) {
-          const next = new URLSearchParams(searchParams);
-          next.set("sessionId", String(resolvedId));
-          setSearchParams(next, { replace: true });
+        if (urlIsValid) {
+          setSessionId(urlIdNum);
+        } else {
+          setSessionId(null);
         }
       })
       .catch((err: unknown) => {
@@ -190,6 +201,11 @@ export default function MyTeamPage() {
 
   // 세션 0개 빈 상태 (sessions 로드 완료 + length === 0)
   const noSessions = sessions !== null && sessions.length === 0;
+  // 세션은 있지만 지금 보고 있을 활성 드래프트가 없음 (Draft 페이지에서 New/Discard
+  // 후, 또는 처음 들어왔는데 URL/active 세션 없음). 옛 세션을 자동으로
+  // 끌어오지 않고 명시적 안내 — "마이팀 = 현재 드래프트" 시맨틱 유지.
+  const noActiveDraft =
+    sessions !== null && sessions.length > 0 && sessionId === null;
   const sessionsLoading = sessions === null && sessionsError === null;
 
   // 클라이언트 측 필터링 + 정렬 (백엔드 재호출 없이 메모리에서 계산)
@@ -241,6 +257,24 @@ export default function MyTeamPage() {
         </FadeIn>
       )}
 
+      {/* 세션은 있지만 현재 활성 드래프트가 없음 (New/Discard 직후 등) */}
+      {noActiveDraft && (
+        <FadeIn delayMs={60}>
+          <section className="rounded-3xl border border-white/10 bg-white/5 p-8 text-center">
+            <h2 className="text-lg font-black text-white">No active draft</h2>
+            <p className="mt-2 text-sm font-semibold text-white/70">
+              Start or load a draft session, and your team will appear here.
+            </p>
+            <Link
+              to="/draft"
+              className="mt-4 inline-block rounded-2xl bg-emerald-500 px-5 py-2 text-sm font-black text-black transition hover:bg-emerald-400"
+            >
+              Go to Draft
+            </Link>
+          </section>
+        </FadeIn>
+      )}
+
       {/* 세션 목록 조회 자체가 실패 */}
       {sessionsError && (
         <FadeIn delayMs={60}>
@@ -251,7 +285,7 @@ export default function MyTeamPage() {
       )}
 
       {/* 본문: 검색/정렬/포지션 필터 + 선수 목록 테이블 */}
-      {!noSessions && !sessionsError && (
+      {!noSessions && !noActiveDraft && !sessionsError && (
       <FadeIn delayMs={60} className="relative z-40">
         <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
           {/* 검색창 + 정렬 드롭다운 */}


### PR DESCRIPTION
## What
<!-- What did you do? -->
- DraftPage mirrors `isLoadedMode + sessionId` to sessionStorage as the
  "active draft session" id.
- MyTeamPage prefers that over URL `?sessionId`, dropping the old
  "most recent saved session" auto-fallback.
- When there's no active draft, show a "No active draft" empty card with
  Go-to-Draft CTA.

## Why
<!-- Why did you do it? -->
Stale URL `?sessionId` made My Team display picks from a previously-loaded
session (Stanton / Solano appeared as "permanently drafted") even after
the user discarded or started a new draft.

## Related Issue
<!-- e.g. #123 -->
#118 