### PR TITLE
X icon on Modal, fix compare bugs

### DIFF
--- a/fe/src/components/ui/Modal.tsx
+++ b/fe/src/components/ui/Modal.tsx
@@ -56,10 +56,13 @@ export default function Modal({
             {title && <h3 className="text-lg font-semibold text-white">{title}</h3>}
           </div>
           <button
+            type="button"
             onClick={onClose}
-            className="rounded-lg border border-white/10 px-2 py-1 text-xs text-white/80 hover:bg-white/5 transition"
+            aria-label="Close"
+            title="Close (Esc)"
+            className="grid h-7 w-7 place-items-center rounded-lg border border-white/10 text-sm text-white/80 hover:bg-white/5 transition"
           >
-            ESC
+            ✕
           </button>
         </div>
 

--- a/fe/src/features/draft/components/DraftHeaderBar.tsx
+++ b/fe/src/features/draft/components/DraftHeaderBar.tsx
@@ -100,7 +100,7 @@ export default function DraftHeaderBar({
             <button
               type="button"
               onClick={onNew}
-              className="rounded-2xl border border-sky-400/30 bg-sky-500/10 px-4 py-3 text-sm font-black text-sky-200 transition hover:bg-sky-500/20"
+              className="rounded-2xl bg-white px-4 py-3 text-sm font-black text-black transition hover:bg-zinc-100"
               title="Start a fresh draft session (re-configure budget / teams / roster)"
             >
               New

--- a/fe/src/features/draft/draftHelpers.ts
+++ b/fe/src/features/draft/draftHelpers.ts
@@ -85,6 +85,16 @@ export function isPitcherPositionFilter(filter: DraftPositionFilter): boolean {
   return filter === "SP" || filter === "RP";
 }
 
+// Compare 기능 — 같은 분류끼리만 비교 허용한다.
+// 타자/포수/유틸은 모두 playerType !== "pitcher" 이므로 한 그룹.
+// SP/RP 는 playerType === "pitcher" 그룹.
+export function arePlayersComparable(
+  a: DraftPlayerPublic,
+  b: DraftPlayerPublic,
+): boolean {
+  return isPitcherOnly(a) === isPitcherOnly(b);
+}
+
 // ── Formatters ────────────────────────────────────────────────────────
 
 export function formatNumber(value: number | null | undefined, digits: number) {

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -51,6 +51,7 @@ import {
   DEFAULT_POSITION_FILTERS,
   PITCHER_SORT_OPTIONS,
   UNSAVED_DRAFT_KEY,
+  arePlayersComparable,
   buildTeamsFromConfig,
   initialNameFor,
   isPitcherPositionFilter,
@@ -349,8 +350,9 @@ export default function DraftPage() {
     return calculateCurrentRound(teams.length, rosterSize, picks);
   }, [teams.length, rosterSize, picks]);
 
-  const selectedA = players.find((player) => player.id === compareAId) ?? null;
-  const selectedB = players.find((player) => player.id === compareBId) ?? null;
+  // 포지션 필터를 바꾸면 paginated `players` 에서 사라질 수 있으므로 전체 lookup 사용.
+  const selectedA = compareAId ? playersById[compareAId] ?? null : null;
+  const selectedB = compareBId ? playersById[compareBId] ?? null : null;
 
   const openAddModal = (player: DraftPlayer) => {
     setAddTarget(player);
@@ -644,6 +646,7 @@ export default function DraftPage() {
   }, [authed, config, picks]);
 
   // Toggle player selection for A/B comparison (max 2 players).
+  // 타자/투수 혼합 비교는 차단하고 토스트로 안내한다.
   const handleCompareToggle = (playerId: string) => {
     if (!authed) return;
     if (comparisonOpen) setComparisonOpen(false);
@@ -656,6 +659,19 @@ export default function DraftPage() {
 
     if (compareBId === playerId) {
       setCompareBId(null);
+      return;
+    }
+
+    const candidate = playersById[playerId];
+    if (!candidate) return;
+    const counterpart = !compareAId
+      ? selectedB
+      : !compareBId
+        ? selectedA
+        : selectedA; // 둘 다 차 있으면 B 를 교체 → A 와 비교 가능해야 함
+
+    if (counterpart && !arePlayersComparable(candidate, counterpart)) {
+      pushToast("타자와 투수는 함께 비교할 수 없어요.", "error");
       return;
     }
 


### PR DESCRIPTION
## What
<!-- What did you do? -->
- Modal close button: replaced `ESC` text label with `X` icon (applies to all modals using the shared Modal component).
- Compare panel:
  - Preserve A/B selection when switching the position filter (look up from full `playersById` instead of the paginated slice).
  - Block batter vs. pitcher comparison with a warning toast. SP/RP compare together; catcher counts as a batter.
 
## Why
<!-- Why did you do it? -->
- The "ESC" label looked awkward; the X icon matches common modal conventions.
- A/B was disappearing on filter change because the lookup ran against the filtered list.
- Mixing batter and pitcher stats in the comparison modal is meaningless and was confusing users.

## Related Issue
<!-- e.g. #123 -->
#120 