### PR TITLE
copy draft, cross-team player move, scrollbar style

### DIFF
--- a/fe/src/features/draft/components/CopySessionModal.tsx
+++ b/fe/src/features/draft/components/CopySessionModal.tsx
@@ -1,0 +1,69 @@
+// Rename-and-copy modal — confirms a name before duplicating a saved session.
+// Presentation only: name state and API call live in the parent (DraftPage).
+
+type Props = {
+  nameInput: string;
+  onChangeName: (next: string) => void;
+  error: string | null;
+  copying: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export default function CopySessionModal({
+  nameInput,
+  onChangeName,
+  error,
+  copying,
+  onCancel,
+  onConfirm,
+}: Props) {
+  return (
+    <div className="fixed inset-0 z-[90] grid place-items-center p-4">
+      <button
+        type="button"
+        aria-label="Close copy dialog"
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onCancel}
+      />
+      <div className="relative w-full max-w-md rounded-3xl border border-white/15 bg-[#0c1220] p-6 shadow-2xl">
+        <div className="text-lg font-black text-white">Copy Draft</div>
+        <div className="mt-1 text-xs text-white/55">
+          Choose a name for the new session
+        </div>
+
+        <input
+          type="text"
+          value={nameInput}
+          onChange={(e) => onChangeName(e.target.value)}
+          placeholder="New session name"
+          className="mt-4 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm font-semibold text-white outline-none placeholder:text-white/40 focus:border-white/25"
+          autoFocus
+        />
+
+        {error && (
+          <div className="mt-2 text-xs font-bold text-rose-300">{error}</div>
+        )}
+
+        <div className="mt-5 flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={copying}
+            className="flex-1 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-black text-white/80 transition hover:bg-white/10 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={copying || nameInput.trim().length === 0}
+            className="flex-1 rounded-2xl bg-sky-500 px-4 py-3 text-sm font-black text-white transition hover:bg-sky-400 disabled:opacity-50"
+          >
+            {copying ? "Copying..." : "Copy"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/features/draft/components/DraftRoomBoard.tsx
+++ b/fe/src/features/draft/components/DraftRoomBoard.tsx
@@ -13,14 +13,15 @@ type Props = {
   view: DraftPickKind;                    // 현재 보고 있는 보드
   onViewChange: (next: DraftPickKind) => void;
   onRemovePick: (pick: DraftPick) => void;
-  // 한 팀 안에서 드래그-드롭으로 슬롯 인덱스를 바꿀 때 호출. (내 팀 + 상대 팀 모두)
-  // teamId 는 드래그가 일어난 팀 — 호출자가 어떤 팀의 픽을 재배치할지 결정하는 데 사용.
-  // 마이너/택시는 자격 검사 없이 순수 재정렬.
+  // 드래그-드롭으로 슬롯/팀을 바꿀 때 호출.
+  //  - fromTeamId === toTeamId: 같은 팀 내 재정렬 (메인은 swap 까지 허용, 마이너/택시는 순수 재정렬)
+  //  - 다르면: 팀 간 이동. 메인 보드는 자격 + 빈 슬롯 검사, 마이너/택시는 자격 없이 빈 슬롯이면 OK.
   onSlotReassign?: (
+    fromTeamId: string,
     fromIndex: number,
+    toTeamId: string,
     toIndex: number,
     kind: DraftPickKind,
-    teamId: string,
   ) => void;
 };
 
@@ -102,21 +103,29 @@ export default function DraftRoomBoard({
 
   if (!authed) return null;
 
-  // 출발 슬롯의 player 가 target 슬롯에 자격이 있는지 확인 (메인만 의미 있음).
-  // 마이너/택시는 슬롯 자격 자체가 없으니 항상 OK.
-  // teamId 는 hover 대상 팀 — 출발 팀과 같지 않으면 드롭 불가.
-  const isHoverEligible = (teamId: string, toIndex: number): boolean => {
+  // 출발 슬롯의 player 가 target 슬롯에 자격이 있는지 확인.
+  //  - 같은 팀: 메인은 자격 검사 (occupied 도 swap 가능하므로 OK 표시), 마이너/택시는 항상 OK.
+  //  - 다른 팀: 빈 슬롯 + 자격 (메인) 또는 빈 슬롯 (마이너/택시) 이어야 한다.
+  const isHoverEligible = (toTeamId: string, toIndex: number): boolean => {
     if (draggingFrom === null) return false;
-    if (draggingFrom.teamId !== teamId) return false;
-    if (draggingFrom.index === toIndex) return true;
-    if (view !== "main") return true;
+    if (draggingFrom.teamId === toTeamId && draggingFrom.index === toIndex) return true;
 
-    const fromPick = (picksByTeam.get(teamId) ?? []).find(
+    const fromPick = (picksByTeam.get(draggingFrom.teamId) ?? []).find(
       (p) => p.slotIndex === draggingFrom.index
     );
     if (!fromPick) return false;
     const player = playersById[fromPick.playerId];
     if (!player) return false;
+
+    const isCrossTeam = draggingFrom.teamId !== toTeamId;
+    if (isCrossTeam) {
+      const targetOccupied = (picksByTeam.get(toTeamId) ?? []).some(
+        (p) => p.slotIndex === toIndex
+      );
+      if (targetOccupied) return false;
+    }
+
+    if (view !== "main") return true;
     const toSlotPos = effectiveSlotTemplate[toIndex];
     if (!toSlotPos) return false;
     return isEligibleForSlot(player.positions, toSlotPos);
@@ -233,8 +242,6 @@ export default function DraftRoomBoard({
                       const dndProps = {
                         onDragOver: (e: React.DragEvent) => {
                           if (draggingFrom === null) return;
-                          // 다른 팀에서 출발한 드래그는 받지 않음 — preventDefault 안 하면 "no-drop" 커서.
-                          if (draggingFrom.teamId !== team.id) return;
                           e.preventDefault();
                           e.dataTransfer.dropEffect = "move";
                           const ok = isHoverEligible(team.id, slotIndex);
@@ -265,10 +272,16 @@ export default function DraftRoomBoard({
                               teamId?: unknown;
                               slotIndex?: unknown;
                             };
-                            if (parsed.teamId !== team.id) return;
+                            if (typeof parsed.teamId !== "string") return;
                             if (typeof parsed.slotIndex !== "number") return;
                             if (!Number.isFinite(parsed.slotIndex)) return;
-                            onSlotReassign?.(parsed.slotIndex, slotIndex, view, team.id);
+                            onSlotReassign?.(
+                              parsed.teamId,
+                              parsed.slotIndex,
+                              team.id,
+                              slotIndex,
+                              view,
+                            );
                           } catch {
                             // ignore malformed payload
                           }

--- a/fe/src/features/draft/components/ImportSessionsModal.tsx
+++ b/fe/src/features/draft/components/ImportSessionsModal.tsx
@@ -10,6 +10,7 @@ type Props = {
   onClose: () => void;
   onPick: (id: number) => void;
   onDelete: (id: number) => void;
+  onCopy: (id: number) => void;
 };
 
 export default function ImportSessionsModal({
@@ -18,6 +19,7 @@ export default function ImportSessionsModal({
   onClose,
   onPick,
   onDelete,
+  onCopy,
 }: Props) {
   return (
     <div className="fixed inset-0 z-[80] grid place-items-center p-4">
@@ -64,6 +66,15 @@ export default function ImportSessionsModal({
                   <div className="mt-0.5 text-xs text-white/55">
                     {s.createdAt.slice(0, 10)}
                   </div>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onCopy(s.id)}
+                  aria-label="Copy session"
+                  title="Duplicate this session as a new draft"
+                  className="rounded-xl border border-sky-400/30 bg-sky-500/10 px-3 py-1.5 text-xs font-black text-sky-200 transition hover:bg-sky-500/20"
+                >
+                  Copy
                 </button>
                 <button
                   type="button"

--- a/fe/src/features/home/InjuredPlayersStrip.tsx
+++ b/fe/src/features/home/InjuredPlayersStrip.tsx
@@ -64,7 +64,7 @@ export default function InjuredPlayersStrip() {
         title={`Injured Players (${players.length})`}
         onClose={() => setOpen(false)}
       >
-        <div className="grid max-h-[60vh] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2">
+        <div className="ppadun-dropdown-scroll grid max-h-[60vh] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2">
           {players.map((p) => (
             <InjuredPlayerCard key={p.player_id} item={p} />
           ))}

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -78,6 +78,7 @@ import CustomizeStatsModal from "../features/draft/components/CustomizeStatsModa
 import SaveSessionModal from "../features/draft/components/SaveSessionModal";
 import NewDraftConfirmModal from "../features/draft/components/NewDraftConfirmModal";
 import ImportSessionsModal from "../features/draft/components/ImportSessionsModal";
+import CopySessionModal from "../features/draft/components/CopySessionModal";
 import PlayerListTable from "../features/draft/components/PlayerListTable";
 import DraftHeaderBar from "../features/draft/components/DraftHeaderBar";
 import PlayerSearchToolbar from "../features/draft/components/PlayerSearchToolbar";
@@ -723,33 +724,51 @@ export default function DraftPage() {
     commitPicks((prev) => prev.filter((p) => p.playerId !== pick.playerId));
   };
 
-  // 내 팀 보드 안에서 드래그로 슬롯을 옮길 때:
-  //   - 메인: 자격(isEligibleForSlot) 검사 후 이동/스왑.
-  //   - 마이너/택시: 포지션 자격이 없으니 순수 재정렬(스왑/빈자리 이동).
-  // kind 는 어느 보드의 슬롯을 만지는지 — 같은 kind 내에서만 인덱스 충돌이 발생.
-  // teamId 는 재배치가 일어난 팀 — 내 팀뿐 아니라 opponent 팀의 픽도 사용자가 직접 정리 가능.
+  // 드래그-드롭으로 슬롯/팀을 옮길 때:
+  //  - 같은 팀: 메인은 자격 검사 후 이동/스왑, 마이너·택시는 순수 재정렬.
+  //  - 다른 팀: 빈 슬롯 + 자격(메인) 일 때만 이동. occupied 면 스왑 대신 토스트로 안내.
   const handleSlotReassign = (
+    fromTeamId: string,
     fromIndex: number,
+    toTeamId: string,
     toIndex: number,
     kind: DraftPickKind,
-    teamId: string,
   ) => {
-    if (fromIndex === toIndex) return;
+    if (fromTeamId === toTeamId && fromIndex === toIndex) return;
 
-    const teamPicks = picks.filter(
-      (p) => p.draftedByTeamId === teamId && p.kind === kind
+    const fromTeamPicks = picks.filter(
+      (p) => p.draftedByTeamId === fromTeamId && p.kind === kind
     );
-    const fromPick = teamPicks.find((p) => p.slotIndex === fromIndex);
+    const fromPick = fromTeamPicks.find((p) => p.slotIndex === fromIndex);
     if (!fromPick) return;
-    const toPick = teamPicks.find((p) => p.slotIndex === toIndex);
 
-    // 마이너/택시: 자격 검사 없이 그냥 스왑/이동.
+    const toTeamPicks = picks.filter(
+      (p) => p.draftedByTeamId === toTeamId && p.kind === kind
+    );
+    const toPick = toTeamPicks.find((p) => p.slotIndex === toIndex);
+    const isCrossTeam = fromTeamId !== toTeamId;
+
+    // 팀 간 이동: occupied 면 스왑 안 함, 토스트로 안내.
+    if (isCrossTeam && toPick) {
+      const targetTeam = teams.find((t) => t.id === toTeamId);
+      pushToast(
+        `${targetTeam?.name ?? "Target team"} already has a player in that slot.`,
+        "error",
+      );
+      return;
+    }
+
+    // 마이너/택시: 자격 검사 없이 처리.
     if (kind !== "main") {
       commitPicks((prev) =>
         prev.map((p) => {
           if (p.kind !== kind) return p;
-          if (p.playerId === fromPick.playerId) return { ...p, slotIndex: toIndex };
-          if (toPick && p.playerId === toPick.playerId) return { ...p, slotIndex: fromIndex };
+          if (p.playerId === fromPick.playerId) {
+            return { ...p, slotIndex: toIndex, draftedByTeamId: toTeamId };
+          }
+          if (toPick && p.playerId === toPick.playerId) {
+            return { ...p, slotIndex: fromIndex };
+          }
           return p;
         })
       );
@@ -768,7 +787,24 @@ export default function DraftPage() {
       return;
     }
 
-    // Empty target → simple move.
+    // 팀 간 이동 (빈 슬롯 확인은 위에서 끝남): teamId + slotIndex + slotPos 교체.
+    if (isCrossTeam) {
+      commitPicks((prev) =>
+        prev.map((p) =>
+          p.playerId === fromPick.playerId
+            ? {
+                ...p,
+                slotIndex: toIndex,
+                slotPos: toSlotPos as DraftPosition,
+                draftedByTeamId: toTeamId,
+              }
+            : p
+        )
+      );
+      return;
+    }
+
+    // 같은 팀 — 빈 target → 단순 이동.
     if (!toPick) {
       commitPicks((prev) =>
         prev.map((p) =>
@@ -780,7 +816,7 @@ export default function DraftPage() {
       return;
     }
 
-    // Occupied target → swap only when both directions are eligible.
+    // 같은 팀 — occupied target → 양방향 자격 모두 OK 일 때만 스왑.
     const toPlayer = playersById[toPick.playerId];
     if (!toPlayer) return;
     if (!isEligibleForSlot(toPlayer.positions, fromSlotPos)) {
@@ -999,6 +1035,11 @@ export default function DraftPage() {
   // ── Import 모달 핸들러 ──
   const [sessionList, setSessionList] = useState<SessionSummary[]>([]);
   const [sessionListLoading, setSessionListLoading] = useState(false);
+  // Copy 흐름: Copy 버튼 클릭 시 rename 모달을 띄우고, Confirm 시 실제 POST.
+  const [copyTarget, setCopyTarget] = useState<{ id: number } | null>(null);
+  const [copyNameInput, setCopyNameInput] = useState("");
+  const [copyError, setCopyError] = useState<string | null>(null);
+  const [copySaving, setCopySaving] = useState(false);
 
   const refreshSessionList = () => {
     setSessionListLoading(true);
@@ -1023,6 +1064,79 @@ export default function DraftPage() {
   const handleSessionPick = (id: number) => {
     closeImportModal();
     navigate(`/draft/${id}`);
+  };
+
+  // Copy 버튼 클릭: rename 모달을 띄운다. 실제 POST 는 handleCopyConfirm.
+  const handleSessionCopy = (id: number) => {
+    const source = sessionList.find((s) => s.id === id);
+    setCopyTarget({ id });
+    setCopyNameInput(source ? `${source.name} (Copy)` : "Copied Draft");
+    setCopyError(null);
+  };
+
+  const closeCopyModal = () => {
+    if (copySaving) return;
+    setCopyTarget(null);
+    setCopyNameInput("");
+    setCopyError(null);
+  };
+
+  // Confirm: 원본 세션 + 메모 로드 → 사용자가 입력한 이름으로 새 세션 POST.
+  const handleCopyConfirm = () => {
+    if (copyTarget === null) return;
+    const name = copyNameInput.trim();
+    if (!name) {
+      setCopyError("Name is required");
+      return;
+    }
+    const sourceId = copyTarget.id;
+    setCopySaving(true);
+    setCopyError(null);
+
+    apiGetAuth<SessionDetail>(`/api/draft/sessions/${sourceId}`)
+      .then(async (original) => {
+        const notesResp = await apiGetAuth<{ items: { playerId: string; note: string }[] }>(
+          `/api/draft/sessions/${sourceId}/notes`,
+        ).catch(() => ({ items: [] }));
+
+        const created = await apiPostAuth<
+          SessionDetail,
+          { name: string; config: DraftConfigServer; picks: DraftPick[] }
+        >("/api/draft/sessions", {
+          name,
+          config: original.config,
+          picks: original.picks,
+        });
+
+        if (notesResp.items.length > 0) {
+          await Promise.all(
+            notesResp.items.map((n) =>
+              apiPutAuth<{ status: string }, { note: string }>(
+                `/api/draft/sessions/${created.id}/notes/${encodeURIComponent(n.playerId)}`,
+                { note: n.note },
+              ).catch((err: unknown) => {
+                console.error(`Failed to copy note for ${n.playerId}:`, err);
+              }),
+            ),
+          );
+        }
+
+        setCopySaving(false);
+        setCopyTarget(null);
+        setCopyNameInput("");
+        pushToast(`Copied as "${created.name}".`, "success");
+        refreshSessionList();
+      })
+      .catch((err: unknown) => {
+        console.error(err);
+        setCopySaving(false);
+        const msg = err instanceof Error ? err.message : "";
+        if (msg.includes("Maximum")) {
+          setCopyError("Reached max session count. Delete one and try again.");
+        } else {
+          setCopyError(msg || "Copy failed");
+        }
+      });
   };
 
   const handleSessionDelete = (id: number) => {
@@ -1245,6 +1359,18 @@ export default function DraftPage() {
           onClose={closeImportModal}
           onPick={handleSessionPick}
           onDelete={handleSessionDelete}
+          onCopy={handleSessionCopy}
+        />
+      )}
+
+      {copyTarget !== null && (
+        <CopySessionModal
+          nameInput={copyNameInput}
+          onChangeName={setCopyNameInput}
+          error={copyError}
+          copying={copySaving}
+          onCancel={closeCopyModal}
+          onConfirm={handleCopyConfirm}
         />
       )}
 


### PR DESCRIPTION


## What
<!-- What did you do? -->
Copy draft session — New "Copy" button in the Import Sessions modal opens a rename dialog (default `"{Original} (Copy)"`). On confirm, a new session is created with the same config + picks + notes.
2. Cross-team player move — Drafted players can be dragged from one team's slot to another team's slot. Main board validates eligibility; if the target slot is occupied, a toast is shown. Moves are undoable (Ctrl+Z).
3. Scrollbar style — "View All" modal on Injured Players uses the shared `ppadun-dropdown-scroll` style instead of the default browser scrollbar.


## Why
<!-- Why did you do it? -->

## Related Issue
<!-- e.g. #123 -->
#125 