### PR TITLE
feat(home): equal-height news/injured + scrollable injured + default news image

### DIFF
--- a/fe/src/features/home/InjuredPlayersStrip.tsx
+++ b/fe/src/features/home/InjuredPlayersStrip.tsx
@@ -1,23 +1,18 @@
 import { useEffect, useState } from "react";
 
-import Modal from "../../components/ui/Modal";
 import type { InjuredPlayer } from "../../types/home";
 import InjuredPlayerCard from "./InjuredPlayerCard";
 
 /**
  * InjuredPlayersStrip: HomePage의 부상자 섹션
- * - 상위 3명 가로 카드 (Latest News 섹션과 같은 outer container 스타일)
- * - "View all →" 클릭 시 전체 명단 popup
+ * - 전체 명단을 한 카드 안에서 세로 스크롤로 표시
+ * - Latest News 섹션과 같은 outer container 스타일 + 같은 높이로 stretch
  *
- * 데이터: GET /api/players/injured (limit 없음 = 전체).
- * - strip은 처음 3명만 slice
- * - popup은 전체 리스트
- * - 한 번만 fetch해서 두 곳 다 사용 (popup 클릭 시 추가 호출 없음)
+ * 데이터: GET /api/home/injured — limit 없이 한 번에 받아서 그대로 렌더.
  */
 
 export default function InjuredPlayersStrip() {
   const [players, setPlayers] = useState<InjuredPlayer[]>([]);
-  const [open, setOpen] = useState(false);
 
   useEffect(() => {
     fetch("/api/home/injured")
@@ -29,47 +24,26 @@ export default function InjuredPlayersStrip() {
   // 부상자가 0명이면 섹션 자체를 숨김 (빈 박스 보여주는 것보다 깔끔)
   if (players.length === 0) return null;
 
-  const top3 = players.slice(0, 3);
-
   return (
-    <>
-      {/* News 섹션과 동일한 outer container 스타일로 sibling 느낌 */}
-      <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
-        <div className="flex items-end justify-between gap-3">
-          <div>
-            <h2 className="text-lg font-bold text-white">Injured Players</h2>
-            <p className="mt-1 text-xs text-white/50">
-              Updated daily · sorted by player value
-            </p>
-          </div>
-          <button
-            onClick={() => setOpen(true)}
-            className="text-xs font-bold text-white/60 hover:text-white transition"
-          >
-            View all →
-          </button>
+    // News 섹션과 동일한 outer container 스타일로 sibling 느낌.
+    // h-full + flex column → HomePage 의 items-stretch grid 와 함께 두 섹션 높이를 맞춤.
+    <section className="flex h-full flex-col rounded-3xl border border-white/10 bg-white/5 p-6">
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-bold text-white">Injured Players</h2>
+          <p className="mt-1 text-xs text-white/50">
+            Updated every 30 minutes · sorted by player value
+          </p>
         </div>
+        <span className="text-xs font-bold text-white/40">{players.length} listed</span>
+      </div>
 
-        {/* 우측 1/3 컬럼에 들어가므로 항상 세로 1열 stack */}
-        <div className="mt-5 grid grid-cols-1 gap-4">
-          {top3.map((p) => (
-            <InjuredPlayerCard key={p.player_id} item={p} />
-          ))}
-        </div>
-      </section>
-
-      {/* View All popup — 같은 카드 컴포넌트로 전체 표시, 스크롤 가능 */}
-      <Modal
-        open={open}
-        title={`Injured Players (${players.length})`}
-        onClose={() => setOpen(false)}
-      >
-        <div className="grid max-h-[60vh] grid-cols-1 gap-3 overflow-y-auto pr-1 sm:grid-cols-2">
-          {players.map((p) => (
-            <InjuredPlayerCard key={p.player_id} item={p} />
-          ))}
-        </div>
-      </Modal>
-    </>
+      {/* 카드 리스트 — flex-1 로 남은 공간 전부 채움, 넘치면 세로 스크롤 */}
+      <div className="mt-5 flex-1 space-y-3 overflow-y-auto pr-1">
+        {players.map((p) => (
+          <InjuredPlayerCard key={p.player_id} item={p} />
+        ))}
+      </div>
+    </section>
   );
 }

--- a/fe/src/features/home/NewsCard.tsx
+++ b/fe/src/features/home/NewsCard.tsx
@@ -19,20 +19,38 @@ export default function NewsCard({ item }: Props) {
       rel="noreferrer"
       className="group relative block w-full overflow-hidden rounded-2xl border border-white/10 bg-white/5 text-left transition hover:bg-white/8 hover:-translate-y-[2px] active:translate-y-0"
     >
-      {/* 좌측 썸네일 + 우측 텍스트 가로 레이아웃. 이미지가 없으면 텍스트만 폭 100% */}
+      {/* 좌측 썸네일 + 우측 텍스트 가로 레이아웃. */}
+      {/* imageUrl 없거나 깨지면 회색 placeholder를 보여서 카드 폭이 항상 일정. */}
       <div className="flex items-stretch gap-4">
-        {/* 썸네일: imageUrl이 있을 때만 렌더. onError로 깨진 이미지는 카드에서 숨김 */}
-        {item.imageUrl && (
-          <div className="relative hidden w-40 shrink-0 overflow-hidden bg-white/5 sm:block">
+        <div className="relative hidden w-40 shrink-0 overflow-hidden bg-white/10 sm:block">
+          {item.imageUrl ? (
             <img
               src={item.imageUrl}
               alt=""
               loading="lazy"
               className="h-full w-full object-cover transition group-hover:scale-105"
-              onError={(e) => { (e.currentTarget.parentElement as HTMLElement).style.display = "none"; }}
+              onError={(e) => {
+                // 깨진 이미지 → placeholder로 fallback (영역 자체는 유지)
+                e.currentTarget.style.display = "none";
+              }}
             />
-          </div>
-        )}
+          ) : (
+            <div className="flex h-full w-full items-center justify-center">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                className="h-10 w-10 text-white/25"
+                aria-hidden="true"
+              >
+                <rect x="3" y="5" width="18" height="14" rx="2" />
+                <circle cx="9" cy="11" r="1.5" />
+                <path d="M21 17l-5-5-6 6" />
+              </svg>
+            </div>
+          )}
+        </div>
 
         {/* 텍스트 영역 */}
         <div className="relative flex-1 p-5">

--- a/fe/src/pages/HomePage.tsx
+++ b/fe/src/pages/HomePage.tsx
@@ -142,17 +142,17 @@ export default function HomePage() {
         </section>
       </FadeIn>
 
-      {/* 뉴스 + 부상 선수 2열 그리드 */}
+      {/* 뉴스 + 부상 선수 2열 그리드 — items-stretch 로 두 카드 세로 길이 동일하게. */}
       {/* grid-cols-1: 기본 1열 / lg:grid-cols-3: 큰 화면에서 3열 */}
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+      <div className="grid grid-cols-1 items-stretch gap-6 lg:grid-cols-3">
         {/* 좌측 뉴스 섹션 (3열 중 2열 차지) */}
-        <FadeIn className="lg:col-span-2" delayMs={60}>
-          <section className="rounded-3xl border border-white/10 bg-white/5 p-6">
+        <FadeIn className="lg:col-span-2 h-full" delayMs={60}>
+          <section className="flex h-full flex-col rounded-3xl border border-white/10 bg-white/5 p-6">
             <div className="flex items-end justify-between gap-3">
               <div>
                 <h2 className="text-lg font-bold text-white">Latest News</h2>
                 <p className="mt-1 text-xs text-white/50">
-                  Fetched from Yahoo Sports · refreshes every hour
+                  Fetched from Yahoo Sports · refreshes every 10 minutes
                 </p>
               </div>
               {/* "모두 보기" 버튼 → Yahoo Sports MLB 뉴스 페이지로 외부 이동 */}
@@ -167,7 +167,7 @@ export default function HomePage() {
             </div>
 
             {/* 뉴스 카드 3개 렌더링 (배열.map으로 반복) */}
-            <div className="mt-5 grid grid-cols-1 gap-4">
+            <div className="mt-5 flex-1 space-y-4">
               {news.map((item) => (
                 // key: React가 리스트 항목을 식별하기 위한 고유값 (필수)
                 <NewsCard key={item.id} item={item} />
@@ -176,8 +176,8 @@ export default function HomePage() {
           </section>
         </FadeIn>
 
-        {/* 우측 부상 선수 섹션 (3열 중 1열) */}
-        <FadeIn className="lg:col-span-1" delayMs={120}>
+        {/* 우측 부상 선수 섹션 (3열 중 1열) — strip 자체가 h-full 로 늘어남 */}
+        <FadeIn className="lg:col-span-1 h-full" delayMs={120}>
           <InjuredPlayersStrip />
         </FadeIn>
       </div>


### PR DESCRIPTION
## What
- **NewsCard fallback image** — when an item has no \`imageUrl\`, render a gray placeholder block with a small camera-style SVG instead of collapsing the thumbnail area. Keeps card widths consistent.
- **Injured Players: scroll instead of top 3 + modal** — removed the \`slice(0, 3)\` and the "View all" modal. The strip now lists every injured player inside a vertical scroll area in the same card.
- **Equal-height layout** — added \`items-stretch\` to the home grid and \`h-full\` + \`flex-col\` on both sections; the inner card list in each uses \`flex-1\` so the two sibling cards always match in height (News drives the height, Injured scrolls within).
- **Refresh-interval text** — Latest News text updated from "every hour" to "every 10 minutes" (matches the 10-min \`setInterval\` in HomePage). Injured Players text updated from "Updated daily" to "Updated every 30 minutes" (matches the api server's external_fetch cadence).

## Why
- The card widths jumped visibly whenever Yahoo's RSS happened to return an item without a thumbnail (about 30% of items). A placeholder keeps the visual rhythm steady.
- The "View all" modal added a second click + lost the user's place in scroll. Inline scroll is one fewer interaction and works the same on mobile.
- Equal heights were the user's explicit request — the asymmetric look between News (3 cards, ~480px) and Injured (3 cards, ~360px) looked unintentional. Now both sections agree on the height set by News.
- The stale "every hour" / "Updated daily" copy was misleading after \#107 (news polling) and \#128 (api external_fetch tuning). Honest text matches behavior.

## Related Issue
- Closes #126