### PR TITLE
ordered draft history, brought-up tracking, start-draft loading overlay

### DIFF
--- a/fe/src/features/draft/components/AddBidModal.tsx
+++ b/fe/src/features/draft/components/AddBidModal.tsx
@@ -1,27 +1,32 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { DraftPlayer } from "../../../types/draft";
+import type { DraftPlayer, DraftTeam } from "../../../types/draft";
 
 type Props = {
   open: boolean;
   player: DraftPlayer | null;
+  teams: DraftTeam[];
   remainingBudget: number;
   onClose: () => void;
-  onConfirm: (bid: number) => void;
+  onConfirm: (bid: number, broughtUpByTeamId: string) => void;
 };
 
 export default function AddBidModal({
   open,
   player,
+  teams,
   remainingBudget,
   onClose,
   onConfirm,
 }: Props) {
+  const myTeam = useMemo(() => teams.find((t) => t.isMine) ?? teams[0], [teams]);
   const initialBid = useMemo(() => {
     if (!player || typeof player.recommendedBid !== "number") return "";
     return String(player.recommendedBid);
   }, [player]);
 
+  // 부모가 player.id 로 `key` 를 지정해 모달을 remount → useState 초기값이 매번 새로 평가됨.
   const [bid, setBid] = useState(initialBid);
+  const [broughtUpByTeamId, setBroughtUpByTeamId] = useState(myTeam?.id ?? "");
   const [minBidErrorOpen, setMinBidErrorOpen] = useState(false);
   const [budgetErrorOpen, setBudgetErrorOpen] = useState(false);
   const minBidTimerRef = useRef<number | null>(null);
@@ -76,7 +81,8 @@ export default function AddBidModal({
       openBudgetError();
       return;
     }
-    onConfirm(parsedBid);
+    if (!broughtUpByTeamId) return;
+    onConfirm(parsedBid, broughtUpByTeamId);
   };
 
   return (
@@ -104,6 +110,21 @@ export default function AddBidModal({
           </div>
 
           <div className="mt-6 space-y-5">
+            <div>
+              <div className="text-xs font-extrabold text-white/70">Brought Up by</div>
+              <select
+                value={broughtUpByTeamId}
+                onChange={(e) => setBroughtUpByTeamId(e.target.value)}
+                className="mt-2 w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm font-extrabold text-white outline-none transition hover:bg-white/5 focus:border-emerald-400/35"
+              >
+                {teams.map((t) => (
+                  <option key={t.id} value={t.id} className="bg-zinc-950 text-white">
+                    {t.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
             <div>
               <div className="text-xs font-extrabold text-white/70">Winning Bid</div>
               <div className="mt-2 flex items-center gap-2">

--- a/fe/src/features/draft/components/DraftRoomBoard.tsx
+++ b/fe/src/features/draft/components/DraftRoomBoard.tsx
@@ -23,6 +23,8 @@ type Props = {
     toIndex: number,
     kind: DraftPickKind,
   ) => void;
+  // Ordered Draft History 모달을 여는 콜백. 메인 보드에서만 노출.
+  onOpenHistory?: () => void;
 };
 
 // Drag payload: { teamId, slotIndex } JSON. teamId 가 일치할 때만 drop 을 허용.
@@ -54,6 +56,7 @@ export default function DraftRoomBoard({
   onViewChange,
   onRemovePick,
   onSlotReassign,
+  onOpenHistory,
 }: Props) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -172,8 +175,20 @@ export default function DraftRoomBoard({
         </div>
 
         {isMainView && (
-          <div className="text-sm font-black text-emerald-400">
-            Round {currentRound} / {totalRounds}
+          <div className="flex items-center gap-3">
+            {onOpenHistory && (
+              <button
+                type="button"
+                onClick={onOpenHistory}
+                className="rounded-xl border border-white/15 bg-black/25 px-3 py-1.5 text-xs font-black text-white/80 transition hover:bg-white/10"
+                title="View ordered draft history"
+              >
+                History
+              </button>
+            )}
+            <div className="text-sm font-black text-emerald-400">
+              Round {currentRound} / {totalRounds}
+            </div>
           </div>
         )}
       </div>

--- a/fe/src/features/draft/components/OrderedDraftHistoryModal.tsx
+++ b/fe/src/features/draft/components/OrderedDraftHistoryModal.tsx
@@ -1,0 +1,87 @@
+// Ordered draft history — main-board picks in chronological order.
+// Columns: Pick # | Brought Up | Player | Position | MLB Team | Won | Bid.
+// 옛 세션은 broughtUpByTeamId 가 null 일 수 있어 "—" 로 표시.
+
+import Modal from "../../../components/ui/Modal";
+import type { DraftPick, DraftPlayer, DraftTeam } from "../../../types/draft";
+
+type Props = {
+  open: boolean;
+  picks: DraftPick[];
+  teams: DraftTeam[];
+  playersById: Record<string, DraftPlayer>;
+  onClose: () => void;
+};
+
+export default function OrderedDraftHistoryModal({
+  open,
+  picks,
+  teams,
+  playersById,
+  onClose,
+}: Props) {
+  const teamNameById: Record<string, string> = Object.fromEntries(
+    teams.map((t) => [t.id, t.name]),
+  );
+
+  const mainPicks = picks.filter((p) => p.kind === "main");
+
+  return (
+    <Modal
+      open={open}
+      title={`Draft History (${mainPicks.length} picks)`}
+      onClose={onClose}
+      size="large"
+    >
+      {mainPicks.length === 0 ? (
+        <div className="rounded-2xl border border-white/10 bg-black/20 p-6 text-sm text-white/65">
+          No picks yet.
+        </div>
+      ) : (
+        <div className="ppadun-dropdown-scroll max-h-[70vh] overflow-y-auto rounded-2xl border border-white/10 bg-black/20">
+          <table className="w-full text-left text-sm">
+            <thead className="sticky top-0 bg-[#0c1220] text-xs font-black uppercase tracking-wider text-white/55">
+              <tr>
+                <th className="px-3 py-2.5 font-black">Pick #</th>
+                <th className="px-3 py-2.5 font-black">Brought Up</th>
+                <th className="px-3 py-2.5 font-black">Player</th>
+                <th className="px-3 py-2.5 font-black">Position</th>
+                <th className="px-3 py-2.5 font-black">MLB Team</th>
+                <th className="px-3 py-2.5 font-black">Won</th>
+                <th className="px-3 py-2.5 text-right font-black">Bid</th>
+              </tr>
+            </thead>
+            <tbody>
+              {mainPicks.map((pick, idx) => {
+                const player = playersById[pick.playerId];
+                const brought = pick.broughtUpByTeamId
+                  ? teamNameById[pick.broughtUpByTeamId] ?? "—"
+                  : "—";
+                const won = teamNameById[pick.draftedByTeamId] ?? "—";
+                const positions = player?.positions?.join("/") ?? pick.slotPos ?? "—";
+                return (
+                  <tr
+                    key={`${pick.playerId}-${idx}`}
+                    className="border-t border-white/5 hover:bg-white/[0.04]"
+                  >
+                    <td className="px-3 py-2 font-black text-white/80">{idx + 1}</td>
+                    <td className="px-3 py-2 text-white/70">{brought}</td>
+                    <td className="px-3 py-2 font-black text-white">
+                      {player?.name ?? pick.playerId}
+                    </td>
+                    <td className="px-3 py-2 text-white/70">{positions}</td>
+                    <td className="px-3 py-2 text-white/70">{player?.team ?? "—"}</td>
+                    <td className="px-3 py-2 font-bold text-white/80">{won}</td>
+                    <td className="px-3 py-2 text-right font-black text-emerald-300">
+                      {typeof pick.bid === "number" ? `$${pick.bid}` : "—"}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/fe/src/features/draft/components/TakenBidModal.tsx
+++ b/fe/src/features/draft/components/TakenBidModal.tsx
@@ -9,7 +9,8 @@ type Props = {
   // 마이너/택시 보드는 bid 가 없음 — 입력 필드/검증 건너뛰고 bid=null 로 confirm.
   kind?: DraftPickKind;
   onClose: () => void;
-  onConfirm: (draftedByTeamId: string, bid: number | null) => void;
+  // Brought Up — 메인 only (마이너/택시는 무료 픽이라 nominator 개념 없음 → null).
+  onConfirm: (draftedByTeamId: string, bid: number | null, broughtUpByTeamId: string | null) => void;
 };
 
 export default function TakenBidModal({
@@ -26,7 +27,9 @@ export default function TakenBidModal({
 
   const initialTeamId = useMemo(() => otherTeams[0]?.id ?? "", [otherTeams]);
 
+  // 부모가 player.id 로 `key` 를 지정해 모달을 remount → useState 초기값이 매번 새로 평가됨.
   const [draftedByTeamId, setDraftedByTeamId] = useState(initialTeamId);
+  const [broughtUpByTeamId, setBroughtUpByTeamId] = useState(initialTeamId);
   const [bid, setBid] = useState("");
   const [minBidErrorOpen, setMinBidErrorOpen] = useState(false);
   const [budgetErrorOpen, setBudgetErrorOpen] = useState(false);
@@ -79,9 +82,9 @@ export default function TakenBidModal({
 
   const handleConfirm = () => {
     if (!validTeam) return;
-    // 마이너/택시는 bid 가 없으니 그대로 confirm.
+    // 마이너/택시는 bid 가 없으니 그대로 confirm. brought-up 도 null.
     if (!isMainKind) {
-      onConfirm(draftedByTeamId, null);
+      onConfirm(draftedByTeamId, null, null);
       return;
     }
     if (!Number.isFinite(parsedBid) || parsedBid < 1) {
@@ -92,7 +95,8 @@ export default function TakenBidModal({
       openBudgetError();
       return;
     }
-    onConfirm(draftedByTeamId, parsedBid);
+    if (!broughtUpByTeamId) return;
+    onConfirm(draftedByTeamId, parsedBid, broughtUpByTeamId);
   };
 
   return (
@@ -138,6 +142,23 @@ export default function TakenBidModal({
                 ))}
               </select>
             </div>
+
+            {isMainKind && (
+              <div className="border-t border-white/10 pt-4">
+                <div className="text-xs font-extrabold text-white/70">Brought Up by</div>
+                <select
+                  value={broughtUpByTeamId}
+                  onChange={(e) => setBroughtUpByTeamId(e.target.value)}
+                  className="mt-2 w-full rounded-2xl border border-white/10 bg-black/40 px-4 py-3 text-sm font-extrabold text-white outline-none transition hover:bg-white/5 focus:border-rose-400/35"
+                >
+                  {teams.map((t) => (
+                    <option key={t.id} value={t.id} className="bg-zinc-950 text-white">
+                      {t.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
 
             {isMainKind && (
               <div className="border-t border-white/10 pt-4">

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -82,6 +82,7 @@ import CopySessionModal from "../features/draft/components/CopySessionModal";
 import PlayerListTable from "../features/draft/components/PlayerListTable";
 import DraftHeaderBar from "../features/draft/components/DraftHeaderBar";
 import PlayerSearchToolbar from "../features/draft/components/PlayerSearchToolbar";
+import OrderedDraftHistoryModal from "../features/draft/components/OrderedDraftHistoryModal";
 import ComparisonPanel from "../features/draft/components/ComparisonPanel";
 import { useStatColumns } from "../features/draft/useStatColumns";
 import { getStatDef } from "../features/draft/statColumns";
@@ -118,6 +119,10 @@ export default function DraftPage() {
 
   // "Start Your Draft" 버튼이 띄우는 setup / 로그인 유도 모달.
   const [setupModalOpen, setSetupModalOpen] = useState(false);
+  const [historyModalOpen, setHistoryModalOpen] = useState(false);
+  // Start Draft 직후 PPA 값 첫 응답을 기다리는 동안 페이지 전체를 블러로 덮어둔다.
+  // 이후 픽 변경에 따른 재계산은 overlay 없이 백그라운드에서 갱신.
+  const [pendingStartDraft, setPendingStartDraft] = useState(false);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
 
   // "New" → "Save first?" Yes 경로에서 Save 가 끝난 직후 setup 모달을
@@ -444,6 +449,8 @@ export default function DraftPage() {
     setNotes({});
     setHasDraftConfig(true);
     setSetupModalOpen(false);
+    // 다음 useEffect 가 새 config 로 PPA 값을 다시 fetch 한다 — overlay 가 그 동안 노출됨.
+    setPendingStartDraft(true);
   };
 
   // 비로그인이면 로그인 모달, 로그인 상태면 setup 모달.
@@ -636,11 +643,14 @@ export default function DraftPage() {
       .then((data) => {
         if (controller.signal.aborted) return;
         setPlayerValues(data.items ?? []);
+        setPendingStartDraft(false);
       })
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return;
         console.error(err);
         setPlayerValues(null);
+        setPendingStartDraft(false);
+        pushToast("Failed to load player values. Please try again.", "error");
       });
 
     return () => controller.abort();
@@ -848,7 +858,8 @@ export default function DraftPage() {
     draftedByTeamId: string,
     bid: number | null,
     type: DraftPick["type"],
-    kind: DraftPickKind
+    kind: DraftPickKind,
+    broughtUpByTeamId: string | null = null,
   ) => {
     const filtered = picks.filter((p) => p.playerId !== playerId);
     const occupied = new Set(
@@ -870,6 +881,7 @@ export default function DraftPage() {
       const next: DraftPick = {
         playerId,
         draftedByTeamId,
+        broughtUpByTeamId,
         slotIndex,
         slotPos: null,
         bid: null,
@@ -897,6 +909,7 @@ export default function DraftPage() {
     const next: DraftPick = {
       playerId,
       draftedByTeamId,
+      broughtUpByTeamId,
       slotIndex,
       slotPos,
       bid,
@@ -919,16 +932,20 @@ export default function DraftPage() {
     openAddModal(player);
   };
 
-  const handleAddFinish = (bid: number) => {
+  const handleAddFinish = (bid: number, broughtUpByTeamId: string) => {
     if (!addTarget || !myTeam) return;
-    if (!addPickToState(addTarget.id, myTeam.id, bid, "mine", "main")) return;
+    if (!addPickToState(addTarget.id, myTeam.id, bid, "mine", "main", broughtUpByTeamId)) return;
     closeAddModal();
     draftRoomTopRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
 
-  const handleTakenFinish = (draftedByTeamId: string, bid: number | null) => {
+  const handleTakenFinish = (
+    draftedByTeamId: string,
+    bid: number | null,
+    broughtUpByTeamId: string | null,
+  ) => {
     if (!takenTarget) return;
-    if (!addPickToState(takenTarget.id, draftedByTeamId, bid, "taken", boardView)) return;
+    if (!addPickToState(takenTarget.id, draftedByTeamId, bid, "taken", boardView, broughtUpByTeamId)) return;
     closeTakenModal();
     draftRoomTopRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
   };
@@ -1201,6 +1218,7 @@ export default function DraftPage() {
               onViewChange={setBoardView}
               onRemovePick={handleRemovePick}
               onSlotReassign={handleSlotReassign}
+              onOpenHistory={() => setHistoryModalOpen(true)}
             />
           ) : (
             <section className="rounded-3xl border border-white/10 bg-white/5 p-8 text-center">
@@ -1281,6 +1299,7 @@ export default function DraftPage() {
           key={`add-${addTarget.id}`}
           open={true}
           player={addTarget}
+          teams={teams}
           remainingBudget={remainingBudget}
           onClose={closeAddModal}
           onConfirm={handleAddFinish}
@@ -1396,7 +1415,46 @@ export default function DraftPage() {
         onAuthSuccess={() => setSetupModalOpen(true)}
       />
 
+      <OrderedDraftHistoryModal
+        open={historyModalOpen}
+        picks={picks}
+        teams={teams}
+        playersById={playersById}
+        onClose={() => setHistoryModalOpen(false)}
+      />
+
       <Toast toasts={toasts} onDismiss={dismissToast} />
+
+      {pendingStartDraft && (
+        <div className="fixed inset-0 z-100 grid place-items-center bg-black/50 backdrop-blur-md">
+          <div className="flex items-center gap-3 rounded-2xl border border-white/15 bg-[#0c1220] px-6 py-5 shadow-2xl">
+            <svg
+              className="h-5 w-5 animate-spin text-white/80"
+              viewBox="0 0 24 24"
+              fill="none"
+              aria-hidden="true"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="3"
+                className="opacity-25"
+              />
+              <path
+                d="M4 12a8 8 0 0 1 8-8"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+              />
+            </svg>
+            <div className="text-sm font-black text-white">
+              Loading player values...
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -96,7 +96,10 @@ export type DraftPickKind = "main" | "minor" | "taxi";
  */
 export type DraftPick = {
   playerId: string;              // 뽑은 선수 ID
-  draftedByTeamId: string;       // 뽑은 팀 ID
+  draftedByTeamId: string;       // 뽑은 팀 ID (Won)
+  // 옥션 드래프트에서 선수를 지명한 팀 (Brought Up). 마이너/택시는 무료 픽이라 null.
+  // 옛 세션은 백엔드에서 null 로 옴 → UI 는 "—" 로 표시.
+  broughtUpByTeamId?: string | null;
   slotIndex: number;             // 로스터 슬롯 번호
   slotPos: string | null;        // 슬롯 포지션 — 마이너/택시는 null
   bid: number | null;            // 낙찰가 ($) — 마이너/택시는 null


### PR DESCRIPTION


## What
<!-- What did you do? -->
1. Ordered Draft History— New "History" button in the Draft Room (left of the Round indicator) opens a modal listing main-draft picks in chronological order: Pick # / Brought Up / Player / Position / MLB Team / Won / Bid.
2. Brought Up tracking — AddBid / TakenBid modals now include a "Brought Up by" dropdown so the nominator (auction-style) is recorded on each pick. Stored as `broughtUpByTeamId` (nullable; old picks display "—").
3. Start Draft loading overlay — After confirming Start Draft, the page is blurred with a centered "Loading player values..." box until PPA values arrive. Failure clears the overlay and shows a toast.


## Why
<!-- Why did you do it? -->
The `broughtUpByTeamId` field is sent in pick payloads. Pydantic ignores unknown fields by default, so this is safe to ship before the backend adds the column. Once the backend persists it, history rows will show real values instead of "—".

## Related Issue
<!-- e.g. #123 -->
#129 