### PR TITLE
refactor(draft): split PPA bulk fetch from per-pick recommended bid

### DIFF
--- a/fe/src/features/draft/components/AddBidModal.tsx
+++ b/fe/src/features/draft/components/AddBidModal.tsx
@@ -6,6 +6,9 @@ type Props = {
   player: DraftPlayer | null;
   teams: DraftTeam[];
   remainingBudget: number;
+  // 부모가 모달이 열릴 때 단건 호출로 채워 넣는 추천 bid (in-flight 동안 null + bidLoading=true).
+  recommendedBid: number | null;
+  bidLoading: boolean;
   onClose: () => void;
   onConfirm: (bid: number, broughtUpByTeamId: string) => void;
 };
@@ -15,17 +18,16 @@ export default function AddBidModal({
   player,
   teams,
   remainingBudget,
+  recommendedBid,
+  bidLoading,
   onClose,
   onConfirm,
 }: Props) {
   const myTeam = useMemo(() => teams.find((t) => t.isMine) ?? teams[0], [teams]);
-  const initialBid = useMemo(() => {
-    if (!player || typeof player.recommendedBid !== "number") return "";
-    return String(player.recommendedBid);
-  }, [player]);
 
   // 부모가 player.id 로 `key` 를 지정해 모달을 remount → useState 초기값이 매번 새로 평가됨.
-  const [bid, setBid] = useState(initialBid);
+  // bid input 은 항상 빈 문자열로 시작 — 추천값은 placeholder 로만 안내.
+  const [bid, setBid] = useState("");
   const [broughtUpByTeamId, setBroughtUpByTeamId] = useState(myTeam?.id ?? "");
   const [minBidErrorOpen, setMinBidErrorOpen] = useState(false);
   const [budgetErrorOpen, setBudgetErrorOpen] = useState(false);
@@ -132,7 +134,13 @@ export default function AddBidModal({
                   value={bid}
                   onChange={(e) => setBid(e.target.value)}
                   inputMode="numeric"
-                  placeholder="Enter winning bid"
+                  placeholder={
+                    bidLoading
+                      ? "Loading recommendation..."
+                      : recommendedBid !== null
+                        ? `Recommended: $${recommendedBid}`
+                        : "Enter winning bid"
+                  }
                   className={[
                     "w-full rounded-2xl bg-black/30 px-4 py-3 text-sm text-white outline-none placeholder:text-white/35",
                     bidInputErrorOpen
@@ -167,7 +175,7 @@ export default function AddBidModal({
             <div className="border-t border-white/10 pt-4">
               <div className="text-xs font-extrabold text-white/70">Draft cost</div>
               <div className="mt-2 text-3xl font-black text-emerald-400">
-                ${player.recommendedBid ?? "—"}
+                {bidLoading ? "..." : recommendedBid !== null ? `$${recommendedBid}` : "—"}
               </div>
               <div className="mt-1 text-xs text-white/35">
                 This is the recommended draft cost baseline.

--- a/fe/src/features/draft/components/PlayerListTable.tsx
+++ b/fe/src/features/draft/components/PlayerListTable.tsx
@@ -15,7 +15,6 @@ import type {
   DraftTeam,
 } from "../../../types/draft";
 import {
-  draftCostClass,
   getPlayerDraftStatus,
   mlbTeamBadgeClass,
   teamAccentClass,
@@ -77,11 +76,10 @@ export default function PlayerListTable({
   return (
     <FadeIn delayMs={140}>
       <section className="overflow-hidden rounded-3xl border border-white/10 bg-white/5">
-        <div className="grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_.9fr_1.3fr_1.1fr_.9fr] bg-black/40 px-4 py-3 text-xs font-extrabold text-white/60">
+        <div className="grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_1.3fr_1.1fr_.9fr] bg-black/40 px-4 py-3 text-xs font-extrabold text-white/60">
           <div className="text-center">#</div>
           <div>Player</div>
           <div className="text-center">Pos</div>
-          <div className="text-center">Cost</div>
           <div className="text-center">Team</div>
           <div className="text-center">{statColumnLabels[0]}</div>
           <div className="text-center">{statColumnLabels[1]}</div>
@@ -130,7 +128,7 @@ export default function PlayerListTable({
                 <div
                   key={player.id}
                   className={[
-                    "grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_.9fr_1.3fr_1.1fr_.9fr] items-center px-4 py-3 text-sm text-white/85 transition tabular-nums",
+                    "grid grid-cols-[.4fr_1.8fr_.6fr_.8fr_.8fr_.8fr_.8fr_.8fr_.8fr_1.3fr_1.1fr_.9fr] items-center px-4 py-3 text-sm text-white/85 transition tabular-nums",
                     compareActive
                       ? "relative z-[1] my-1 rounded-xl border border-emerald-400/75 bg-emerald-500/10 shadow-[0_0_18px_rgba(16,185,129,0.35)]"
                       : "hover:bg-white/5",
@@ -191,8 +189,6 @@ export default function PlayerListTable({
                       {player.positions[0]}
                     </span>
                   </div>
-
-                  <div className={`text-center ${draftCostClass(authed)}`}>${player.recommendedBid ?? "—"}</div>
 
                   <div className="text-center">
                     <span

--- a/fe/src/features/draft/draftHelpers.ts
+++ b/fe/src/features/draft/draftHelpers.ts
@@ -35,7 +35,6 @@ export const DEFAULT_POSITION_FILTERS: DraftPositionFilter[] = [
 
 export const BATTER_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
   { value: "score_desc", label: "By Score" },
-  { value: "cost_desc",  label: "By Draft Cost" },
   { value: "avg_desc",   label: "By AVG" },
   { value: "hr_desc",    label: "By HR" },
   { value: "rbi_desc",   label: "By RBI" },
@@ -44,7 +43,6 @@ export const BATTER_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
 
 export const PITCHER_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
   { value: "score_desc", label: "By Score" },
-  { value: "cost_desc",  label: "By Draft Cost" },
   { value: "avg_desc",   label: "By ERA" },
   { value: "hr_desc",    label: "By SO" },
   { value: "rbi_desc",   label: "By W" },
@@ -222,9 +220,7 @@ export function mergePlayersWithValues(
   const valueById = new Map(values.map((v) => [v.playerId, v]));
   return publicPlayers.map((player) => {
     const v = valueById.get(player.id);
-    return v
-      ? { ...player, ppaValue: v.ppaValue, recommendedBid: v.recommendedBid }
-      : { ...player };
+    return v ? { ...player, ppaValue: v.ppaValue } : { ...player };
   });
 }
 

--- a/fe/src/features/draft/utils.ts
+++ b/fe/src/features/draft/utils.ts
@@ -117,11 +117,6 @@ export function formatAvg(avg: number | null) {
   return avg.toFixed(3).replace("0.", ".");
 }
 
-/** Draft cost style — blurred for unauthenticated users. */
-export function draftCostClass(authed: boolean) {
-  return authed ? "text-white/80" : "blur-sm select-none text-white/50";
-}
-
 /**
  * 선수의 positions 가 해당 슬롯의 position 에 대해 자격을 가지는지 확인.
  *   BENCH: 누구든 OK

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -24,6 +24,7 @@ import type {
   DraftPick,
   DraftPickKind,
   DraftPlayer,
+  DraftPlayerBid,
   DraftPlayerPublic,
   DraftPlayerValue,
   DraftPositionFilter,
@@ -212,6 +213,9 @@ export default function DraftPage() {
   const [boardView, setBoardView] = useState<DraftPickKind>("main");
 
   const [addTarget, setAddTarget] = useState<DraftPlayer | null>(null);
+  // Add 모달이 열릴 때 즉석에서 단건 호출하는 추천 bid + 그 in-flight 상태.
+  const [addTargetBid, setAddTargetBid] = useState<number | null>(null);
+  const [addTargetBidLoading, setAddTargetBidLoading] = useState(false);
   const [takenTarget, setTakenTarget] = useState<DraftPlayer | null>(null);
 
   // 메모 — playerId → note. 로드 모드에서만 fetch/저장 동작 (세션 ID 필요).
@@ -290,8 +294,6 @@ export default function DraftPage() {
 
     const sorted = [...result].sort((a, b) => {
       switch (sort) {
-        case "cost_desc":
-          return (b.recommendedBid ?? 0) - (a.recommendedBid ?? 0);
         case "avg_desc":
           return primaryRateSortValue(b) - primaryRateSortValue(a);
         case "hr_desc":
@@ -370,6 +372,8 @@ export default function DraftPage() {
 
   const closeAddModal = () => {
     setAddTarget(null);
+    setAddTargetBid(null);
+    setAddTargetBidLoading(false);
   };
 
   const closeTakenModal = () => {
@@ -620,12 +624,9 @@ export default function DraftPage() {
     return () => controller.abort();
   }, [leagueQuery]);
 
-  // 인증된 사용자에게만 PPA 값 + 추천 bid 를 불러와 playerId 로 공개 목록과 머지한다.
+  // 인증된 사용자에게만 PPA 값을 불러와 playerId 로 공개 목록과 머지한다.
+  // recommendedBid 는 Add 모달이 열릴 때 단건으로 따로 호출 (POST /api/draft/players/bid).
   // 로그아웃 시 값을 즉시 지워서 UI 에 남지 않도록 함.
-  // picks/config 가 바뀔 때마다 재호출 — 잔여 예산 변동에 따라 백엔드의 추천 bid 가 갱신되기 때문.
-  // hasDraftConfig 는 의도적으로 의존하지 않음 — 로그인만 하면 (Start Draft 누르기 전에도)
-  // PPA 값이 보여야 한다. 드래프트 시작 전엔 config 가 DEFAULT_DRAFT_CONFIG 로 채워져 있어서
-  // 백엔드가 기본 예산/로스터/상대수로 추천 bid 를 계산해 돌려준다.
   useEffect(() => {
     if (!authed || !config) {
       queueMicrotask(() => setPlayerValues(null));
@@ -634,11 +635,10 @@ export default function DraftPage() {
 
     const controller = new AbortController();
 
-    apiPostAuth<DraftPlayerValuesResponse, { config: DraftConfigServer; picks: DraftPick[] }>(
-      "/api/draft/players/values",
-      { config, picks },
+    apiGetAuth<DraftPlayerValuesResponse>(
+      "/api/draft/players/value",
       undefined,
-      controller.signal
+      controller.signal,
     )
       .then((data) => {
         if (controller.signal.aborted) return;
@@ -654,7 +654,7 @@ export default function DraftPage() {
       });
 
     return () => controller.abort();
-  }, [authed, config, picks]);
+  }, [authed, config]);
 
   // Toggle player selection for A/B comparison (max 2 players).
   // 타자/투수 혼합 비교는 차단하고 토스트로 안내한다.
@@ -920,7 +920,7 @@ export default function DraftPage() {
     return true;
   };
 
-  // Add 버튼 클릭 — 메인이면 bid 모달, 마이너/택시는 바로 추가.
+  // Add 버튼 클릭 — 메인이면 bid 모달 (열면서 단건 bid fetch), 마이너/택시는 바로 추가.
   const handleAddClick = (player: DraftPlayer) => {
     if (boardView !== "main") {
       if (!myTeam) return;
@@ -929,7 +929,20 @@ export default function DraftPage() {
       }
       return;
     }
+    if (!config) return;
     openAddModal(player);
+    setAddTargetBid(null);
+    setAddTargetBidLoading(true);
+    apiPostAuth<DraftPlayerBid, { playerId: string; config: DraftConfigServer; picks: DraftPick[] }>(
+      "/api/draft/players/bid",
+      { playerId: player.id, config, picks },
+    )
+      .then((res) => setAddTargetBid(res.recommendedBid))
+      .catch((err: unknown) => {
+        console.error(err);
+        setAddTargetBid(null);
+      })
+      .finally(() => setAddTargetBidLoading(false));
   };
 
   const handleAddFinish = (bid: number, broughtUpByTeamId: string) => {
@@ -1301,6 +1314,8 @@ export default function DraftPage() {
           player={addTarget}
           teams={teams}
           remainingBudget={remainingBudget}
+          recommendedBid={addTargetBid}
+          bidLoading={addTargetBidLoading}
           onClose={closeAddModal}
           onConfirm={handleAddFinish}
         />

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -50,19 +50,28 @@ export type DraftPlayerPublic = {
 };
 
 /**
- * DraftPlayerValue: 인증 필요 /api/draft/players/values 가 돌려주는 가치 정보
+ * DraftPlayerValue: 인증 필요 GET /api/draft/players/value 가 돌려주는 가치 정보
  * - playerId 를 키로 DraftPlayerPublic 과 머지해서 DraftPlayer 를 구성
+ * - recommendedBid 는 모달에서 단건으로 따로 호출 (DraftPlayerBid)
  */
 export type DraftPlayerValue = {
   playerId: string;
   ppaValue: number | null;       // PPA-DUN 가치 점수
-  recommendedBid: number | null; // 추천 드래프트 비용
+};
+
+/**
+ * DraftPlayerBid: POST /api/draft/players/bid 단건 응답
+ * - Add 버튼 클릭 시 모달이 열리는 동안 즉석에서 호출
+ */
+export type DraftPlayerBid = {
+  playerId: string;
+  recommendedBid: number | null;
 };
 
 /**
  * DraftPlayer: UI 에서 사용하는 머지된 선수 타입
- * - 비로그인 또는 값 조회 실패 시 ppaValue / recommendedBid 가 undefined 가 될 수 있음
- * - 표시 시점에 formatPpa() / ?? 등으로 방어 필요
+ * - ppaValue 는 일괄 fetch 로 채워짐. recommendedBid 는 머지 흐름에서 채우지 않음 (모달 props 로 전달).
+ *   타입은 호환성을 위해 optional 로 남겨두지만, mergePlayersWithValues 는 더 이상 세팅하지 않는다.
  */
 export type DraftPlayer = DraftPlayerPublic & {
   ppaValue?: number | null;
@@ -185,8 +194,6 @@ export type PlayerNote = {
 export type DraftSort =
   | "score_desc"
   | "score_asc"
-  | "cost_desc"
-  | "cost_asc"
   | "avg_desc"
   | "hr_desc"
   | "rbi_desc"


### PR DESCRIPTION


## What
<!-- What did you do? -->
1. Bulk PPA fetch — `POST /api/draft/players/values` (heavy, recomputed every pick) → `GET /api/draft/players/value` (PPA only, static, cacheable). No longer depends on picks/config.
2. Per-pick recommended bid — Recommended bid is now fetched on-demand when the Add modal opens via `POST /api/draft/players/bid` with `{playerId, config, picks}`. Result drives the modal only; not merged into the player object.
3. UI cleanup — Cost column removed from the player list. Cost-related sort options dropped. `recommendedBid` no longer required on `DraftPlayer` (kept optional for backward compat with Compare features).
4. AddBidModal — Input starts empty; recommendation shown as placeholder ("Recommended: $N" / "Loading recommendation..." / "Enter winning bid") and as the secondary "Draft cost" baseline below.

## Why
<!-- Why did you do it? -->
The previous bulk endpoint recomputed every recommended bid on every pick change, which was getting slow. PPA value is static per player so it can be cached; recommendation is only needed at the moment of bidding.

## Related Issue
<!-- e.g. #123 -->
#131 