### PR TITLE
feat: lock stat columns to 5 slots; pre-fetch compare bid; remove Car…

### DIFF
--- a/fe/src/features/draft/components/PlayerListTable.tsx
+++ b/fe/src/features/draft/components/PlayerListTable.tsx
@@ -30,9 +30,10 @@ type Props = {
   pageSize: number;
   totalPages: number;
   onChangePage: (next: number) => void;
-  statColumnLabels: string[];
-  batterCols: string[];
-  pitcherCols: string[];
+  // 길이 5 고정. null 슬롯은 빈 셀 / 빈 헤더로 렌더해 좌우 밀림 방지.
+  statColumnLabels: (string | null)[];
+  batterCols: (string | null)[];
+  pitcherCols: (string | null)[];
   loading: boolean;
   error: string | null;
   authed: boolean;
@@ -81,11 +82,11 @@ export default function PlayerListTable({
           <div>Player</div>
           <div className="text-center">Pos</div>
           <div className="text-center">Team</div>
-          <div className="text-center">{statColumnLabels[0]}</div>
-          <div className="text-center">{statColumnLabels[1]}</div>
-          <div className="text-center">{statColumnLabels[2]}</div>
-          <div className="text-center">{statColumnLabels[3]}</div>
-          <div className="text-center">{statColumnLabels[4]}</div>
+          <div className="text-center">{statColumnLabels[0] ?? ""}</div>
+          <div className="text-center">{statColumnLabels[1] ?? ""}</div>
+          <div className="text-center">{statColumnLabels[2] ?? ""}</div>
+          <div className="text-center">{statColumnLabels[3] ?? ""}</div>
+          <div className="text-center">{statColumnLabels[4] ?? ""}</div>
           <div className="text-center">PPA-Value</div>
           <div className="text-center">Action</div>
           <div className="text-center">Compare</div>
@@ -202,16 +203,16 @@ export default function PlayerListTable({
                   </div>
 
                   {(isPitcherOnly(player) ? pitcherCols : batterCols).map((key, colIdx) => {
-                    const def = getStatDef(key);
+                    const def = key ? getStatDef(key) : null;
                     const value = def ? def.accessor(player) : null;
-                    const display = def ? def.format(value) : "—";
+                    const display = key === null ? "" : def ? def.format(value) : "—";
                     // 짝수 컬럼 옅은 화이트, 홀수 컬럼 앰버 강조 — 시선 흐름.
                     const cellClass =
                       colIdx % 2 === 0
                         ? "text-center text-white/70"
                         : "text-center font-semibold text-amber-300";
                     return (
-                      <div key={key} className={cellClass}>
+                      <div key={`stat-${colIdx}`} className={cellClass}>
                         {display}
                       </div>
                     );

--- a/fe/src/features/draft/components/StatPickerStrip.tsx
+++ b/fe/src/features/draft/components/StatPickerStrip.tsx
@@ -1,10 +1,11 @@
-// Inline 스탯 5종 선택기. 드래프트 페이지의 Compare 패널과 PlayerListTable 사이에 배치.
-// 포지션 필터에 따라 batter / pitcher 카탈로그를 자동 전환 (SP/RP → pitcher).
-//   - 좌측: 현재 선택된 5개 칩 — 드래그로 순서 변경 / X 로 제거
-//   - 우측: 카탈로그에서 아직 안 고른 칩들 — 클릭으로 추가 (5개 다 차면 비활성)
-// 변경은 즉시 useStatColumns 훅 → localStorage 로 반영된다 (별도 Save 없음).
+// Inline 스탯 5칸 선택기. 드래프트 페이지의 Compare 패널과 PlayerListTable 사이 배치.
+// 항상 5칸이 고정되어 있고, 빈 칸은 점선 placeholder. X 는 자리를 null 로 만들고
+// + 는 첫 빈 자리를 채우므로 다른 컬럼이 좌우로 밀려나지 않는다.
+// 포지션 필터에 따라 batter / pitcher 카탈로그 자동 전환 (SP/RP → pitcher).
+// 변경은 즉시 useStatColumns 훅 → localStorage 로 반영된다.
 
 import { useState } from "react";
+import type { StatSlot } from "../useStatColumns";
 import {
   STAT_COLUMN_COUNT,
   getStatDef,
@@ -16,29 +17,44 @@ const DRAG_MIME = "application/x-ppadun-statkey";
 
 type Props = {
   group: StatGroup;
-  cols: string[];
-  onChange: (next: string[]) => void;
+  cols: StatSlot[];
+  onChange: (next: StatSlot[]) => void;
 };
 
 export default function StatPickerStrip({ group, cols, onChange }: Props) {
   const [draggingIdx, setDraggingIdx] = useState<number | null>(null);
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
 
-  const allInGroup = getStatsForGroup(group);
-  const available = allInGroup.filter((s) => !cols.includes(s.key));
-  const isFull = cols.length >= STAT_COLUMN_COUNT;
+  const slots: StatSlot[] = cols.length === STAT_COLUMN_COUNT
+    ? cols
+    : [...cols, ...Array<StatSlot>(STAT_COLUMN_COUNT - cols.length).fill(null)].slice(0, STAT_COLUMN_COUNT);
+  const filledCount = slots.filter((s) => s !== null).length;
 
-  const addKey = (key: string) => {
-    if (isFull) return;
-    onChange([...cols, key]);
+  const allInGroup = getStatsForGroup(group);
+  const available = allInGroup.filter((s) => !slots.includes(s.key));
+
+  // X 클릭: 해당 슬롯을 null 로 바꿈 (자리는 유지).
+  const clearSlot = (slotIdx: number) => {
+    const next = [...slots];
+    next[slotIdx] = null;
+    onChange(next);
   };
-  const removeKey = (key: string) => onChange(cols.filter((k) => k !== key));
-  const reorder = (from: number, to: number) => {
+
+  // 첫 빈 슬롯에 채워 넣음.
+  const addKey = (key: string) => {
+    const firstEmpty = slots.findIndex((s) => s === null);
+    if (firstEmpty === -1) return;
+    const next = [...slots];
+    next[firstEmpty] = key;
+    onChange(next);
+  };
+
+  // 5칸 사이 swap — 빈 칸 ↔ 빈 칸도 의미 없으니 그냥 swap.
+  const swap = (from: number, to: number) => {
     if (from === to || from < 0 || to < 0) return;
-    if (from >= cols.length || to >= cols.length) return;
-    const next = [...cols];
-    const [item] = next.splice(from, 1);
-    next.splice(to, 0, item);
+    if (from >= slots.length || to >= slots.length) return;
+    const next = [...slots];
+    [next[from], next[to]] = [next[to], next[from]];
     onChange(next);
   };
 
@@ -49,47 +65,69 @@ export default function StatPickerStrip({ group, cols, onChange }: Props) {
           {group === "batter" ? "Batter Stats" : "Pitcher Stats"}
         </div>
         <div className="text-xs font-black text-white/55">
-          {cols.length} / {STAT_COLUMN_COUNT} selected
+          {filledCount} / {STAT_COLUMN_COUNT} selected
         </div>
       </div>
 
-      {/* 선택된 5개 — 드래그로 순서 변경 */}
+      {/* 5 fixed slots — 빈 칸은 점선 placeholder, 채워진 칸은 chip. 드래그로 swap. */}
       <div className="mt-2 flex flex-wrap gap-2">
-        {cols.map((key, idx) => {
-          const def = getStatDef(key);
+        {slots.map((key, idx) => {
+          const def = key ? getStatDef(key) : null;
           const isHover = hoverIdx === idx && draggingIdx !== null && draggingIdx !== idx;
           const isDragging = draggingIdx === idx;
+
+          const dragHandlers = {
+            onDragStart: (e: React.DragEvent) => {
+              if (key === null) return;
+              e.dataTransfer.setData(DRAG_MIME, String(idx));
+              e.dataTransfer.effectAllowed = "move";
+              setDraggingIdx(idx);
+            },
+            onDragEnd: () => {
+              setDraggingIdx(null);
+              setHoverIdx(null);
+            },
+            onDragOver: (e: React.DragEvent) => {
+              if (draggingIdx === null) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+              if (hoverIdx !== idx) setHoverIdx(idx);
+            },
+            onDragLeave: () => {
+              if (hoverIdx === idx) setHoverIdx(null);
+            },
+            onDrop: (e: React.DragEvent) => {
+              e.preventDefault();
+              const raw = e.dataTransfer.getData(DRAG_MIME);
+              setHoverIdx(null);
+              setDraggingIdx(null);
+              if (!raw) return;
+              const from = Number(raw);
+              if (Number.isFinite(from)) swap(from, idx);
+            },
+          };
+
+          if (key === null) {
+            return (
+              <div
+                key={`empty-${idx}`}
+                {...dragHandlers}
+                className={[
+                  "flex min-w-16 items-center justify-center rounded-full border-2 border-dashed px-3 py-1 text-xs font-extrabold text-white/35 transition",
+                  isHover ? "border-emerald-300 ring-2 ring-emerald-300/40" : "border-white/15",
+                ].join(" ")}
+                title="Empty slot — pick a stat below"
+              >
+                Empty
+              </div>
+            );
+          }
+
           return (
             <div
-              key={key}
+              key={`${key}-${idx}`}
               draggable
-              onDragStart={(e) => {
-                e.dataTransfer.setData(DRAG_MIME, String(idx));
-                e.dataTransfer.effectAllowed = "move";
-                setDraggingIdx(idx);
-              }}
-              onDragEnd={() => {
-                setDraggingIdx(null);
-                setHoverIdx(null);
-              }}
-              onDragOver={(e) => {
-                if (draggingIdx === null) return;
-                e.preventDefault();
-                e.dataTransfer.dropEffect = "move";
-                if (hoverIdx !== idx) setHoverIdx(idx);
-              }}
-              onDragLeave={() => {
-                if (hoverIdx === idx) setHoverIdx(null);
-              }}
-              onDrop={(e) => {
-                e.preventDefault();
-                const raw = e.dataTransfer.getData(DRAG_MIME);
-                setHoverIdx(null);
-                setDraggingIdx(null);
-                if (!raw) return;
-                const from = Number(raw);
-                if (Number.isFinite(from)) reorder(from, idx);
-              }}
+              {...dragHandlers}
               className={[
                 "flex cursor-grab items-center gap-1.5 rounded-full border bg-emerald-500/15 px-3 py-1 text-xs font-extrabold text-emerald-100 transition active:cursor-grabbing",
                 isHover ? "border-emerald-300 ring-2 ring-emerald-300/50" : "border-emerald-400/40",
@@ -101,7 +139,7 @@ export default function StatPickerStrip({ group, cols, onChange }: Props) {
               <span>{def?.label ?? key}</span>
               <button
                 type="button"
-                onClick={() => removeKey(key)}
+                onClick={() => clearSlot(idx)}
                 aria-label={`Remove ${def?.label ?? key}`}
                 title="Remove"
                 className="ml-0.5 grid h-4 w-4 place-items-center rounded-full text-[10px] font-black text-emerald-100/80 hover:bg-emerald-400/30"
@@ -111,26 +149,26 @@ export default function StatPickerStrip({ group, cols, onChange }: Props) {
             </div>
           );
         })}
-        {cols.length === 0 && (
-          <div className="text-xs text-white/50">Pick {STAT_COLUMN_COUNT} stats below.</div>
-        )}
       </div>
 
-      {/* 사용 가능한 나머지 — 클릭으로 추가 */}
+      {/* 사용 가능한 나머지 — 클릭으로 첫 빈 슬롯 채움. */}
       {available.length > 0 && (
         <div className="mt-3 flex flex-wrap gap-1.5 border-t border-white/5 pt-3">
-          {available.map((s) => (
-            <button
-              key={s.key}
-              type="button"
-              onClick={() => addKey(s.key)}
-              disabled={isFull}
-              title={isFull ? "Remove one stat first" : `Add ${s.label}`}
-              className="rounded-full border border-white/10 bg-white/5 px-2.5 py-0.5 text-xs font-extrabold text-white/75 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white/5"
-            >
-              + {s.label}
-            </button>
-          ))}
+          {available.map((s) => {
+            const noEmpty = filledCount >= STAT_COLUMN_COUNT;
+            return (
+              <button
+                key={s.key}
+                type="button"
+                onClick={() => addKey(s.key)}
+                disabled={noEmpty}
+                title={noEmpty ? "Remove one stat first" : `Add ${s.label}`}
+                className="rounded-full border border-white/10 bg-white/5 px-2.5 py-0.5 text-xs font-extrabold text-white/75 transition hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-white/5"
+              >
+                + {s.label}
+              </button>
+            );
+          })}
         </div>
       )}
     </section>

--- a/fe/src/features/draft/useStatColumns.ts
+++ b/fe/src/features/draft/useStatColumns.ts
@@ -1,9 +1,8 @@
-// Hook backing the user's per-group stat-column selection (5 keys each).
-// Values live in localStorage so the choice persists across reloads on
-// this device only — same scope as ppadun_unsaved_draft.
-//
-// Reads validate length and key membership; bad data falls back to
-// defaults rather than crashing the page.
+// Hook backing the user's per-group stat-column selection (exactly 5 slots each).
+// 슬롯은 항상 5개로 고정 — 비어 있는 자리는 null. 한 자리를 빼도 다른 컬럼이
+// 좌측으로 밀려나지 않도록, X 는 자리를 null 로 만들고 + 는 첫 빈 자리를 채운다.
+// Values live in localStorage so the choice persists across reloads on this
+// device only — same scope as ppadun_unsaved_draft.
 
 import { useCallback, useState } from "react";
 import {
@@ -15,6 +14,8 @@ import {
   type StatGroup,
 } from "./statColumns";
 
+export type StatSlot = string | null;
+
 const BATTER_KEY = "ppadun_batter_stat_columns";
 const PITCHER_KEY = "ppadun_pitcher_stat_columns";
 
@@ -22,28 +23,40 @@ function storageKey(group: StatGroup): string {
   return group === "batter" ? BATTER_KEY : PITCHER_KEY;
 }
 
-function readCols(group: StatGroup): string[] {
-  const defaults = getDefaultsForGroup(group);
+// 항상 길이 5. 짧으면 null 로 패딩, 길면 앞 5개만 취한다.
+function normalizeLength(cols: StatSlot[]): StatSlot[] {
+  if (cols.length === STAT_COLUMN_COUNT) return cols;
+  if (cols.length > STAT_COLUMN_COUNT) return cols.slice(0, STAT_COLUMN_COUNT);
+  return [...cols, ...Array<StatSlot>(STAT_COLUMN_COUNT - cols.length).fill(null)];
+}
+
+function readCols(group: StatGroup): StatSlot[] {
+  const defaults: StatSlot[] = [...getDefaultsForGroup(group)];
   try {
     const raw = localStorage.getItem(storageKey(group));
-    if (!raw) return [...defaults];
+    if (!raw) return normalizeLength(defaults);
     const parsed = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return [...defaults];
-    if (parsed.length > STAT_COLUMN_COUNT) return [...defaults];
-    // Every entry must be a known key in the matching group; otherwise
-    // the data is stale (e.g. backend renamed a column) and we reset.
+    if (!Array.isArray(parsed)) return normalizeLength(defaults);
+    // 옛 저장본 호환: 5보다 길면 reset, 짧으면 null 패딩.
+    const slots: StatSlot[] = [];
     for (const k of parsed) {
-      if (typeof k !== "string") return [...defaults];
+      if (k === null) {
+        slots.push(null);
+        continue;
+      }
+      if (typeof k !== "string") return normalizeLength(defaults);
       const def = getStatDef(k);
-      if (!def || def.group !== group) return [...defaults];
+      // 그룹이 안 맞으면 손상된 데이터로 보고 기본값으로 복귀.
+      if (!def || def.group !== group) return normalizeLength(defaults);
+      slots.push(k);
     }
-    return parsed as string[];
+    return normalizeLength(slots);
   } catch {
-    return [...defaults];
+    return normalizeLength(defaults);
   }
 }
 
-function writeCols(group: StatGroup, cols: string[]): void {
+function writeCols(group: StatGroup, cols: StatSlot[]): void {
   try {
     localStorage.setItem(storageKey(group), JSON.stringify(cols));
   } catch {
@@ -53,41 +66,37 @@ function writeCols(group: StatGroup, cols: string[]): void {
 }
 
 export type UseStatColumns = {
-  batterCols: string[];
-  pitcherCols: string[];
-  setBatterCols: (cols: string[]) => void;
-  setPitcherCols: (cols: string[]) => void;
+  batterCols: StatSlot[];
+  pitcherCols: StatSlot[];
+  setBatterCols: (cols: StatSlot[]) => void;
+  setPitcherCols: (cols: StatSlot[]) => void;
   resetToDefaults: (group: StatGroup) => void;
 };
 
 export function useStatColumns(): UseStatColumns {
-  const [batterCols, setBatterColsState] = useState<string[]>(() => readCols("batter"));
-  const [pitcherCols, setPitcherColsState] = useState<string[]>(() => readCols("pitcher"));
+  const [batterCols, setBatterColsState] = useState<StatSlot[]>(() => readCols("batter"));
+  const [pitcherCols, setPitcherColsState] = useState<StatSlot[]>(() => readCols("pitcher"));
 
-  // Inline picker 가 한 칸씩 추가/제거 하는 동안의 중간 상태 (0..5) 도 허용한다.
-  // 5 초과만 거부. localStorage 도 같은 정책으로 저장.
-  const setBatterCols = useCallback((cols: string[]) => {
-    if (cols.length > STAT_COLUMN_COUNT) return;
-    writeCols("batter", cols);
-    setBatterColsState(cols);
+  // 항상 길이 5 유지. 다른 길이가 들어와도 normalize 해서 일관성 보장.
+  const setBatterCols = useCallback((cols: StatSlot[]) => {
+    const next = normalizeLength(cols);
+    writeCols("batter", next);
+    setBatterColsState(next);
   }, []);
 
-  const setPitcherCols = useCallback((cols: string[]) => {
-    if (cols.length > STAT_COLUMN_COUNT) return;
-    writeCols("pitcher", cols);
-    setPitcherColsState(cols);
+  const setPitcherCols = useCallback((cols: StatSlot[]) => {
+    const next = normalizeLength(cols);
+    writeCols("pitcher", next);
+    setPitcherColsState(next);
   }, []);
 
   const resetToDefaults = useCallback((group: StatGroup) => {
-    if (group === "batter") {
-      const next = [...BATTER_DEFAULT_KEYS];
-      writeCols("batter", next);
-      setBatterColsState(next);
-    } else {
-      const next = [...PITCHER_DEFAULT_KEYS];
-      writeCols("pitcher", next);
-      setPitcherColsState(next);
-    }
+    const next: StatSlot[] = normalizeLength([
+      ...(group === "batter" ? BATTER_DEFAULT_KEYS : PITCHER_DEFAULT_KEYS),
+    ]);
+    writeCols(group, next);
+    if (group === "batter") setBatterColsState(next);
+    else setPitcherColsState(next);
   }, []);
 
   return { batterCols, pitcherCols, setBatterCols, setPitcherCols, resetToDefaults };

--- a/fe/src/features/players/components/PlayerInfoModal.tsx
+++ b/fe/src/features/players/components/PlayerInfoModal.tsx
@@ -297,13 +297,6 @@ export default function PlayerInfoModal({ open, playerId, playerType = "batter",
               </div>
             </section>
 
-            <section>
-              <div className="mb-2 text-sm font-black uppercase tracking-wide text-white/55">Career History (MLB)</div>
-              <div className="rounded-xl border border-white/10 bg-[#0f1424] p-4 text-sm text-white/70">
-                Planned for development in V2.
-              </div>
-            </section>
-
             {twoWay && (
               <section>
                 <div className="mb-2 text-sm font-black uppercase tracking-wide text-white/55">Two-Way Player Profile</div>

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -196,7 +196,8 @@ export default function DraftPage() {
   // 사용자가 선택한 5개 스탯 (타자/투수 별도) — localStorage에 영구 저장.
   const { batterCols, pitcherCols, setBatterCols, setPitcherCols } = useStatColumns();
   const activeStatKeys = showingPitcherColumns ? pitcherCols : batterCols;
-  const statColumnLabels = activeStatKeys.map((k) => getStatDef(k)?.label ?? k);
+  // 슬롯이 null 이면 헤더 라벨도 빈 문자열 — 좌우 컬럼이 안 밀리도록.
+  const statColumnLabels = activeStatKeys.map((k) => (k ? getStatDef(k)?.label ?? k : ""));
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -361,6 +362,11 @@ export default function DraftPage() {
   // 포지션 필터를 바꾸면 paginated `players` 에서 사라질 수 있으므로 전체 lookup 사용.
   const selectedA = compareAId ? playersById[compareAId] ?? null : null;
   const selectedB = compareBId ? playersById[compareBId] ?? null : null;
+
+  // Compare 슬롯/모달/AI 모두 recommendedBid 를 필요로 함 — 선택되는 즉시 단건 호출로 미리 채움.
+  // 같은 선수가 재선택되면 다시 안 부르고, A/B 가 비면 즉시 null 로 reset.
+  const [compareBidA, setCompareBidA] = useState<number | null>(null);
+  const [compareBidB, setCompareBidB] = useState<number | null>(null);
 
   const openAddModal = (player: DraftPlayer) => {
     setAddTarget(player);
@@ -656,6 +662,71 @@ export default function DraftPage() {
 
     return () => controller.abort();
   }, [authed, config]);
+
+  // Compare A 가 바뀔 때마다 단건 bid 호출 — Compare 슬롯/모달/AI 가 같이 사용한다.
+  // 선택이 바뀌는 순간 옛 bid 가 새 선수에게 잘못 적용되지 않도록 microtask 로 reset.
+  // picks 는 fetch payload 에만 들어가고 deps 에는 빠짐 — 픽 마다 재호출하면 비싸기 때문.
+  useEffect(() => {
+    if (!authed || !config || !compareAId) {
+      queueMicrotask(() => setCompareBidA(null));
+      return;
+    }
+    queueMicrotask(() => setCompareBidA(null));
+    const controller = new AbortController();
+    apiPostAuth<DraftPlayerBid, { playerId: string; config: DraftConfigServer; picks: DraftPick[] }>(
+      "/api/draft/players/bid",
+      { playerId: compareAId, config, picks },
+      undefined,
+      controller.signal,
+    )
+      .then((res) => {
+        if (controller.signal.aborted) return;
+        setCompareBidA(res.recommendedBid);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.error(err);
+        setCompareBidA(null);
+      });
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authed, config, compareAId]);
+
+  useEffect(() => {
+    if (!authed || !config || !compareBId) {
+      queueMicrotask(() => setCompareBidB(null));
+      return;
+    }
+    queueMicrotask(() => setCompareBidB(null));
+    const controller = new AbortController();
+    apiPostAuth<DraftPlayerBid, { playerId: string; config: DraftConfigServer; picks: DraftPick[] }>(
+      "/api/draft/players/bid",
+      { playerId: compareBId, config, picks },
+      undefined,
+      controller.signal,
+    )
+      .then((res) => {
+        if (controller.signal.aborted) return;
+        setCompareBidB(res.recommendedBid);
+      })
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        console.error(err);
+        setCompareBidB(null);
+      });
+    return () => controller.abort();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authed, config, compareBId]);
+
+  // bid 가 채워진 선수 객체 — ComparisonPanel / PlayerComparisonModal / AI 추천 모두 동일한 객체 사용.
+  const selectedAWithBid = useMemo(
+    () => (selectedA ? { ...selectedA, recommendedBid: compareBidA } : null),
+    [selectedA, compareBidA],
+  );
+  const selectedBWithBid = useMemo(
+    () => (selectedB ? { ...selectedB, recommendedBid: compareBidB } : null),
+    [selectedB, compareBidB],
+  );
 
   // Toggle player selection for A/B comparison (max 2 players).
   // 타자/투수 혼합 비교는 차단하고 토스트로 안내한다.
@@ -1274,8 +1345,8 @@ export default function DraftPage() {
       />
 
       <ComparisonPanel
-        selectedA={selectedA}
-        selectedB={selectedB}
+        selectedA={selectedAWithBid}
+        selectedB={selectedBWithBid}
         authed={authed}
         onClearA={clearCompareA}
         onClearB={clearCompareB}
@@ -1342,9 +1413,9 @@ export default function DraftPage() {
       )}
 
       <PlayerComparisonModal
-        open={comparisonOpen && Boolean(selectedA) && Boolean(selectedB)}
-        playerA={selectedA}
-        playerB={selectedB}
+        open={comparisonOpen && Boolean(selectedAWithBid) && Boolean(selectedBWithBid)}
+        playerA={selectedAWithBid}
+        playerB={selectedBWithBid}
         onClose={() => setComparisonOpen(false)}
       />
 


### PR DESCRIPTION


## What
<!-- What did you do? -->
1. Stat picker and player list always render exactly 5 fixed slots. Removing a stat leaves an Empty placeholder in place; Add fills the first empty slot; drag swaps between any two slots including empties.
2. Selecting a player for Compare A or B immediately calls POST /api/draft/players/bid for that player. The fetched bid flows into the Compare slot box, the Compare modal (Draft Cost row, value-per-dollar), and the AI recommendation payload.
3. Dropped the Career History (Planned for V2) section from the Player Info modal.


## Why
<!-- Why did you do it? -->
1. Previously, removing a stat reduced the array length and the remaining stat columns visibly shifted left in the player list — disorienting while users were trying to compare values. Fixed 5-slot layout keeps every column in place so only the chosen slot changes.
2. Recommended bid had moved to an on-demand single-player call when the Add modal opens. The Compare flow still needed it for Draft Cost, value-per-dollar, and the AI recommendation gating, so the Compare features were silently broken. Pre-fetching on selection brings them back to life.
3. Career History was a placeholder that has never been built and is not on the roadmap. Removing the empty section reduces visual noise in the Player Info modal.

## Related Issue
<!-- e.g. #123 -->
#137 