### PR TITLE
stat picker reset button; player detail Depth Chart box

### DIFF
--- a/fe/src/features/draft/components/StatPickerStrip.tsx
+++ b/fe/src/features/draft/components/StatPickerStrip.tsx
@@ -19,9 +19,10 @@ type Props = {
   group: StatGroup;
   cols: StatSlot[];
   onChange: (next: StatSlot[]) => void;
+  onReset: () => void;
 };
 
-export default function StatPickerStrip({ group, cols, onChange }: Props) {
+export default function StatPickerStrip({ group, cols, onChange, onReset }: Props) {
   const [draggingIdx, setDraggingIdx] = useState<number | null>(null);
   const [hoverIdx, setHoverIdx] = useState<number | null>(null);
 
@@ -64,8 +65,18 @@ export default function StatPickerStrip({ group, cols, onChange }: Props) {
         <div className="text-xs font-black uppercase tracking-wider text-white/55">
           {group === "batter" ? "Batter Stats" : "Pitcher Stats"}
         </div>
-        <div className="text-xs font-black text-white/55">
-          {filledCount} / {STAT_COLUMN_COUNT} selected
+        <div className="flex items-center gap-3">
+          <div className="text-xs font-black text-white/55">
+            {filledCount} / {STAT_COLUMN_COUNT} selected
+          </div>
+          <button
+            type="button"
+            onClick={onReset}
+            title={`Reset ${group === "batter" ? "batter" : "pitcher"} stats to defaults`}
+            className="rounded-full border border-white/10 bg-black/30 px-2.5 py-0.5 text-xs font-extrabold text-white/70 transition hover:bg-white/10"
+          >
+            Reset
+          </button>
         </div>
       </div>
 

--- a/fe/src/features/players/components/PlayerInfoModal.tsx
+++ b/fe/src/features/players/components/PlayerInfoModal.tsx
@@ -70,7 +70,16 @@ type PlayerDetailResponse = {
   headshotUrl?: string | null;
   batterStats?: BatterStats | null;
   pitcherStats?: PitcherStats | null;
+  // MLB 팀의 (team, position) 안에서 이 선수의 뎁스 차트 순서. 1=starter. null=미정.
+  depth_order?: number | null;
 };
+
+function formatDepthOrder(order: number | null | undefined): { value: string; label: string } {
+  if (order === null || order === undefined) return { value: "—", label: "Unknown" };
+  if (order === 1) return { value: "1", label: "Starter" };
+  if (order === 2) return { value: "2", label: "Backup" };
+  return { value: String(order), label: "Reserve" };
+}
 
 const HITTER_POSITIONS = new Set([
   "C",
@@ -250,6 +259,29 @@ export default function PlayerInfoModal({ open, playerId, playerType = "batter",
                   </div>
                 ))}
               </div>
+            </section>
+
+            <section>
+              <div className="mb-2 text-sm font-black uppercase tracking-wide text-white/55">Depth Chart</div>
+              {(() => {
+                const depth = formatDepthOrder(detail.depth_order);
+                const knownDepth = detail.depth_order !== null && detail.depth_order !== undefined;
+                return (
+                  <div className="flex items-center gap-4 rounded-xl border border-white/10 bg-[#0f1424] p-4">
+                    <div className="grid h-16 w-16 place-items-center rounded-2xl border border-emerald-400/30 bg-emerald-500/10 text-3xl font-black text-emerald-300">
+                      {depth.value}
+                    </div>
+                    <div className="flex-1">
+                      <div className="text-base font-black text-white">{depth.label}</div>
+                      <div className="mt-0.5 text-xs text-white/55">
+                        {knownDepth
+                          ? `${detail.team} ${detail.positions[0] ?? ""} depth order`.trim()
+                          : "Depth order not available for this player."}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })()}
             </section>
 
             <section>

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -194,7 +194,7 @@ export default function DraftPage() {
   const sortOptions = showingPitcherColumns ? PITCHER_SORT_OPTIONS : BATTER_SORT_OPTIONS;
 
   // 사용자가 선택한 5개 스탯 (타자/투수 별도) — localStorage에 영구 저장.
-  const { batterCols, pitcherCols, setBatterCols, setPitcherCols } = useStatColumns();
+  const { batterCols, pitcherCols, setBatterCols, setPitcherCols, resetToDefaults: resetStatColumns } = useStatColumns();
   const activeStatKeys = showingPitcherColumns ? pitcherCols : batterCols;
   // 슬롯이 null 이면 헤더 라벨도 빈 문자열 — 좌우 컬럼이 안 밀리도록.
   const statColumnLabels = activeStatKeys.map((k) => (k ? getStatDef(k)?.label ?? k : ""));
@@ -1358,6 +1358,7 @@ export default function DraftPage() {
         group={showingPitcherColumns ? "pitcher" : "batter"}
         cols={showingPitcherColumns ? pitcherCols : batterCols}
         onChange={showingPitcherColumns ? setPitcherCols : setBatterCols}
+        onReset={() => resetStatColumns(showingPitcherColumns ? "pitcher" : "batter")}
       />
 
       <PlayerListTable


### PR DESCRIPTION

## What
<!-- What did you do? -->
1. Reset button in the inline stat picker header restores the default 5 stats for the current group (batter or pitcher) using useStatColumns.resetToDefaults. The button reads the active group from the position filter so one click resets only the stats currently visible.
2. Player Info modal now reads a new depth_order field from /api/players/{player_id} and shows a Depth Chart box between Personal Info and Season Stats. 1 = Starter, 2 = Backup, 3+ = Reserve, null = Unknown.


## Why
<!-- Why did you do it? -->
1. After we replaced the modal with an inline picker, users had no quick way to undo a bunch of changes back to defaults. Reset gives them a single-click escape.
2. Depth chart position is one of the V2 enhancements the professor flagged. The backend now caches depth_order in batter_caching / pitcher_caching, and the frontend was the missing piece to surface it to users.

## Related Issue
<!-- e.g. #123 -->
#140 