### PR TITLE
chore: toast UX polish — 5s, close button, drop red-dot, collapse burst

### DIFF
--- a/fe/src/components/ui/Toast.tsx
+++ b/fe/src/components/ui/Toast.tsx
@@ -23,7 +23,7 @@ const VARIANT_CLASS: Record<ToastVariant, string> = {
   depth: "border-amber-400/60 bg-amber-500/25 text-amber-50",
 };
 
-const DEFAULT_DISMISS_MS = 3500;
+const DEFAULT_DISMISS_MS = 5000;
 
 export default function Toast({ toasts, onDismiss }: Props) {
   // 각 toast 가 마운트되면 (개별 durationMs 또는 기본 시간 후) 자동 dismiss.
@@ -48,11 +48,29 @@ export default function Toast({ toasts, onDismiss }: Props) {
         <div
           key={t.id}
           className={[
-            "pointer-events-auto max-w-sm rounded-2xl border px-4 py-3 text-sm font-semibold shadow-lg backdrop-blur",
+            "pointer-events-auto flex max-w-sm items-start gap-3 rounded-2xl border px-4 py-3 text-sm font-semibold shadow-lg backdrop-blur",
             VARIANT_CLASS[t.variant],
           ].join(" ")}
         >
-          {t.text}
+          <span className="flex-1">{t.text}</span>
+          <button
+            type="button"
+            onClick={() => onDismiss(t.id)}
+            aria-label="Dismiss notification"
+            className="-mr-1 -mt-1 shrink-0 rounded-md p-1 text-current opacity-60 transition hover:bg-white/10 hover:opacity-100"
+          >
+            <svg
+              viewBox="0 0 20 20"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2}
+              strokeLinecap="round"
+              className="h-3.5 w-3.5"
+              aria-hidden="true"
+            >
+              <path d="M5 5l10 10M15 5L5 15" />
+            </svg>
+          </button>
         </div>
       ))}
     </div>

--- a/fe/src/features/draft/components/PlayerListTable.tsx
+++ b/fe/src/features/draft/components/PlayerListTable.tsx
@@ -39,7 +39,6 @@ type Props = {
   authed: boolean;
   hasDraftConfig: boolean;
   notes: Record<string, string>;
-  affectedPlayerIds: Set<string>;
   compareAId: string | null;
   compareBId: string | null;
   onAddPick: (player: DraftPlayerPublic) => void;
@@ -65,7 +64,6 @@ export default function PlayerListTable({
   authed,
   hasDraftConfig,
   notes,
-  affectedPlayerIds,
   compareAId,
   compareBId,
   onAddPick,
@@ -138,13 +136,6 @@ export default function PlayerListTable({
                   <div className="text-center text-white/45">{(page - 1) * pageSize + idx + 1}</div>
 
                   <div className="min-w-0 flex items-center gap-1">
-                    {affectedPlayerIds.has(player.id) && (
-                      <span
-                        className="inline-block h-2 w-2 shrink-0 rounded-full bg-rose-500 animate-pulse"
-                        title="Recent update"
-                        aria-label="Recent update"
-                      />
-                    )}
                     <button
                       type="button"
                       onClick={() => onOpenPlayerInfo(player.id, player.playerType)}

--- a/fe/src/hooks/useNotificationPolling.ts
+++ b/fe/src/hooks/useNotificationPolling.ts
@@ -3,7 +3,9 @@
 // 동작:
 // 1. 마운트 시 첫 호출 응답의 latest_id 로 lastSeen을 맞춤 → 그 시점 이전의 모든
 //    알림은 무시 (토스트 안 띄움).
-// 2. 그 이후 polling은 since=lastSeen 으로 새로 들어온 알림만 받아 onEvent 호출.
+// 2. 그 이후 polling은 since=lastSeen 으로 새로 들어온 알림만 받아 onEvents 호출.
+//    한 cycle 의 새 events 를 통째로 배열로 전달 → 호출 측이 batch (e.g. 한 개로
+//    합쳐서 toast) 처리 가능. 매 이벤트마다 콜백 호출하면 toast 폭격이 됨.
 //
 // localStorage catch-up은 의도적으로 안 함 — 사용자가 자는 동안 쌓인 알림을
 // 깨어나서 한꺼번에 토스트로 받는 게 오히려 불편하다는 피드백 반영.
@@ -21,15 +23,15 @@ type Response = {
 };
 
 export function useNotificationPolling(
-  onEvent: (ev: NotificationEvent) => void,
+  onEvents: (evs: NotificationEvent[]) => void,
   enabled: boolean
 ) {
   // 콜백을 ref에 넣어둠 — 매 polling 호출이 최신 콜백을 보게 하면서도
-  // effect deps에 onEvent를 안 넣어 매 렌더마다 polling 재시작되는 일 방지.
-  const onEventRef = useRef(onEvent);
+  // effect deps에 onEvents를 안 넣어 매 렌더마다 polling 재시작되는 일 방지.
+  const onEventsRef = useRef(onEvents);
   useEffect(() => {
-    onEventRef.current = onEvent;
-  }, [onEvent]);
+    onEventsRef.current = onEvents;
+  }, [onEvents]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -54,10 +56,12 @@ export function useNotificationPolling(
         const items = data.items ?? [];
         if (items.length === 0) return;
 
+        // lastSeenId 는 콜백 호출 전에 갱신해두면 콜백이 던지더라도 같은 이벤트가
+        // 다음 tick 에 다시 안 들어옴.
         for (const ev of items) {
-          onEventRef.current(ev);
           if (ev.id > lastSeenId) lastSeenId = ev.id;
         }
+        onEventsRef.current(items);
       } catch (err) {
         // 401, 5xx, 네트워크 끊김 등 — 다음 tick에 재시도하므로 조용히 처리.
         if (!cancelled) console.warn("notification polling failed:", err);

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -101,6 +101,24 @@ import LoginPromptModal from "../features/auth/LoginPromptModal";
 
 const PAGE_SIZE = 30;
 
+// Notification event_type → toast prefix + variant 매핑.
+// 알 수 없는 type 은 일반 알림 fallback.
+function notificationDisplay(eventType: string): {
+  prefix: string;
+  variant: ToastVariant;
+} {
+  switch (eventType) {
+    case "INJURY":
+      return { prefix: "🏥 INJURY UPDATE", variant: "injury" };
+    case "DEPTH":
+      return { prefix: "📊 DEPTH CHART UPDATE", variant: "depth" };
+    case "NEWS":
+      return { prefix: "📰 MLB NEWS", variant: "info" };
+    default:
+      return { prefix: "🔔 NOTIFICATION", variant: "info" };
+  }
+}
+
 // Pure helpers, constants, and inline response/payload types live in
 // `draftHelpers.ts` so this file stays focused on orchestration. See that
 // module for: matchesPositionFilter, isPitcherOnly, isPitcherPositionFilter,
@@ -222,35 +240,26 @@ export default function DraftPage() {
   // 메모 — playerId → note. 로드 모드에서만 fetch/저장 동작 (세션 ID 필요).
   const [notes, setNotes] = useState<Record<string, string>>({});
   const [noteTarget, setNoteTarget] = useState<DraftPlayer | null>(null);
-  const [noteSaving, setNoteSaving] = useState(false);
+  // 15초마다 백엔드 알림 폴링. 한 cycle에서 새 이벤트가 여러 개 들어오면
+  // toast 폭격을 피하려고 한 개로 합쳐서 보여준다 (가장 최근 이벤트 메시지 + 카운트).
+  useNotificationPolling((evs: NotificationEvent[]) => {
+    if (evs.length === 0) return;
 
-  // 부상/뎁스 변경 알림 받은 선수 id 집합 — 페이지 떠나기 전까지 row에 빨간 점 표시.
-  const [affectedPlayerIds, setAffectedPlayerIds] = useState<Set<string>>(new Set());
+    if (evs.length === 1) {
+      const ev = evs[0];
+      const { prefix, variant } = notificationDisplay(ev.event_type);
+      pushToast(`${prefix} — ${ev.message}`, variant);
+      return;
+    }
 
-  // 15초마다 백엔드 알림 폴링. 새 이벤트마다 toast + affectedPlayerIds 업데이트.
-  // event_type 별로 prefix와 색을 다르게 → 사용자가 한눈에 종류 파악 가능.
-  // 토스트는 8초간 유지 (기본 3.5초보다 길게) 해서 메시지 읽을 시간 확보.
-  useNotificationPolling((ev: NotificationEvent) => {
-    const isInjury = ev.event_type === "INJURY";
-    const isDepth = ev.event_type === "DEPTH";
-    const prefix = isInjury
-      ? "🏥 INJURY UPDATE"
-      : isDepth
-        ? "📊 DEPTH CHART UPDATE"
-        : "🔔 NOTIFICATION";
-    const variant: ToastVariant = isInjury
-      ? "injury"
-      : isDepth
-        ? "depth"
-        : "info";
-
-    pushToast(`${prefix} — ${ev.message}`, variant, 8000);
-
-    setAffectedPlayerIds((prev) => {
-      const next = new Set(prev);
-      next.add(ev.player_id);
-      return next;
-    });
+    // 여러 개 — 가장 최근 (id가 가장 큰) 이벤트를 대표로 표시하고 나머지는 카운트로.
+    const sorted = [...evs].sort((a, b) => b.id - a.id);
+    const latest = sorted[0];
+    const { prefix, variant } = notificationDisplay(latest.event_type);
+    pushToast(
+      `${prefix} — ${latest.message} (+${evs.length - 1} more)`,
+      variant
+    );
   }, authed);
 
   // Save / Import 모달
@@ -1376,7 +1385,6 @@ export default function DraftPage() {
         authed={authed}
         hasDraftConfig={hasDraftConfig}
         notes={notes}
-        affectedPlayerIds={affectedPlayerIds}
         compareAId={compareAId}
         compareBId={compareBId}
         onAddPick={handleAddClick}


### PR DESCRIPTION
Closes #141.

## Summary

- `Toast.tsx`: `DEFAULT_DISMISS_MS` 3500 → 5000; added X close button that calls `onDismiss(id)` immediately.
- `DraftPage.tsx` + `PlayerListTable.tsx`: removed the `affectedPlayerIds` Set and the red-dot badge it drove. Toast alone is enough signal.
- `useNotificationPolling.ts`: callback signature changed from `(ev) => void` to `(evs) => void`. The hook now delivers one cycle's new events as a batch so the caller can collapse them.
- `DraftPage.tsx`: notification callback collapses bursts — 1 event → 1 toast as before; N events → 1 toast with the latest message and "(+N-1 more)".

Also added a `notificationDisplay()` helper that maps `event_type` to prefix+variant; now also handles upcoming `NEWS` events (MLB news push feature shipping separately in api repo).

## Test plan

- [ ] `npm run dev` and trigger a fake push via api `/admin/player-event` → toast shows for 5s with a working X button.
- [ ] Fire 3+ events within a 15s polling window → only one toast appears with `(+N more)`.
- [ ] Confirm no red dot anywhere on player rows in the Draft Kit.
- [ ] tsc + eslint pass.