### PR TITLE
silent save, rename modal, MyTeam auto-sync

### DIFF
--- a/fe/src/features/draft/components/DraftHeaderBar.tsx
+++ b/fe/src/features/draft/components/DraftHeaderBar.tsx
@@ -26,6 +26,8 @@ type Props = {
   // Start Draft = open the setup modal (or login modal if not authed).
   // Only rendered when there is no draft in progress.
   onStartDraft: () => void;
+  // 세션 이름 변경 — 로드된 세션에서만 펜슬 버튼이 노출된다.
+  onRename: () => void;
 };
 
 export default function DraftHeaderBar({
@@ -45,15 +47,32 @@ export default function DraftHeaderBar({
   onSave,
   onImport,
   onStartDraft,
+  onRename,
 }: Props) {
   return (
     <FadeIn>
       <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
         <div>
           <div className="text-sm font-black text-white/70">PPA-DUN</div>
-          <h1 className="mt-1 text-3xl font-black text-white">
-            {sessionName ?? "Draft Room"}
-          </h1>
+          <div className="mt-1 flex items-center gap-2">
+            <h1 className="text-3xl font-black text-white">
+              {sessionName ?? "Draft Room"}
+            </h1>
+            {isLoadedMode && sessionName && (
+              <button
+                type="button"
+                onClick={onRename}
+                aria-label="Rename session"
+                title="Rename session"
+                className="grid h-7 w-7 place-items-center rounded-lg border border-white/15 bg-black/25 text-white/70 transition hover:bg-white/10 hover:text-white"
+              >
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="h-3.5 w-3.5">
+                  <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+                  <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5Z" />
+                </svg>
+              </button>
+            )}
+          </div>
           {hasDraftConfig && config ? (
             <p className="mt-2 text-sm text-white/60">
               {String(config.leagueType ?? "AL").toUpperCase()} - ${config.budget} Budget - {rosterSize} Players

--- a/fe/src/features/draft/components/RenameSessionModal.tsx
+++ b/fe/src/features/draft/components/RenameSessionModal.tsx
@@ -1,0 +1,68 @@
+// Rename a saved session — small input + Cancel / Save. Presentation only:
+// state and PUT call live in the parent (DraftPage).
+
+type Props = {
+  nameInput: string;
+  onChangeName: (next: string) => void;
+  error: string | null;
+  saving: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+};
+
+export default function RenameSessionModal({
+  nameInput,
+  onChangeName,
+  error,
+  saving,
+  onCancel,
+  onConfirm,
+}: Props) {
+  return (
+    <div className="fixed inset-0 z-90 grid place-items-center p-4">
+      <button
+        type="button"
+        aria-label="Close rename dialog"
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onCancel}
+      />
+      <div className="relative w-full max-w-md rounded-3xl border border-white/15 bg-[#0c1220] p-6 shadow-2xl">
+        <div className="text-lg font-black text-white">Rename Session</div>
+        <div className="mt-1 text-xs text-white/55">Pick a new name for this draft</div>
+
+        <input
+          type="text"
+          value={nameInput}
+          onChange={(e) => onChangeName(e.target.value)}
+          placeholder="Session name"
+          className="mt-4 w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-sm font-semibold text-white outline-none placeholder:text-white/40 focus:border-white/25"
+          autoFocus
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && nameInput.trim()) onConfirm();
+          }}
+        />
+
+        {error && <div className="mt-2 text-xs font-bold text-rose-300">{error}</div>}
+
+        <div className="mt-5 flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={saving}
+            className="flex-1 rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-sm font-black text-white/80 transition hover:bg-white/10 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={saving || nameInput.trim().length === 0}
+            className="flex-1 rounded-2xl bg-emerald-500 px-4 py-3 text-sm font-black text-white transition hover:bg-emerald-400 disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -78,6 +78,7 @@ import PlayerComparisonModal from "../features/draft/components/PlayerComparison
 import PlayerNotePopover from "../features/draft/components/PlayerNotePopover";
 import StatPickerStrip from "../features/draft/components/StatPickerStrip";
 import SaveSessionModal from "../features/draft/components/SaveSessionModal";
+import RenameSessionModal from "../features/draft/components/RenameSessionModal";
 import NewDraftConfirmModal from "../features/draft/components/NewDraftConfirmModal";
 import ImportSessionsModal from "../features/draft/components/ImportSessionsModal";
 import CopySessionModal from "../features/draft/components/CopySessionModal";
@@ -270,6 +271,12 @@ export default function DraftPage() {
   const [saveNameInput, setSaveNameInput] = useState("");
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+
+  // Rename 모달 — 로드된 세션의 이름 변경 전용.
+  const [renameModalOpen, setRenameModalOpen] = useState(false);
+  const [renameInput, setRenameInput] = useState("");
+  const [renameError, setRenameError] = useState<string | null>(null);
+  const [renameSaving, setRenameSaving] = useState(false);
   const [importModalOpen, setImportModalOpen] = useState(false);
 
   const rosterSize = useMemo(
@@ -1056,6 +1063,111 @@ export default function DraftPage() {
     setSaveModalOpen(true);
   };
 
+  // Save 버튼 — 로드된 세션이면 이름 입력 없이 곧바로 PUT, 성공 시 토스트.
+  // 미저장(신규) 모드는 기존 흐름 그대로 SaveSessionModal 을 띄움.
+  const handleSaveClick = () => {
+    if (!isLoadedMode || sessionId === null || !config || !sessionName) {
+      openSaveModal();
+      return;
+    }
+    setSaving(true);
+    apiPutAuth<SessionDetail, { name: string; picks: DraftPick[] }>(
+      `/api/draft/sessions/${sessionId}`,
+      { name: sessionName, picks },
+    )
+      .then((data) => {
+        setSessionName(data.name);
+        pushToast("Session saved.", "success");
+      })
+      .catch((err: unknown) => {
+        console.error(err);
+        pushToast(
+          err instanceof Error ? `Save failed: ${err.message}` : "Save failed.",
+          "error",
+        );
+      })
+      .finally(() => setSaving(false));
+  };
+
+  // 펜슬 아이콘 → rename 모달.
+  const openRenameModal = () => {
+    setRenameInput(sessionName ?? "");
+    setRenameError(null);
+    setRenameModalOpen(true);
+  };
+
+  const closeRenameModal = () => {
+    if (renameSaving) return;
+    setRenameModalOpen(false);
+    setRenameError(null);
+  };
+
+  const handleRenameConfirm = () => {
+    if (sessionId === null) return;
+    const next = renameInput.trim();
+    if (!next) {
+      setRenameError("Name cannot be empty");
+      return;
+    }
+    if (next === sessionName) {
+      // 변경 없음 — 그냥 닫기.
+      setRenameModalOpen(false);
+      return;
+    }
+    setRenameSaving(true);
+    setRenameError(null);
+    apiPutAuth<SessionDetail, { name: string; picks: DraftPick[] }>(
+      `/api/draft/sessions/${sessionId}`,
+      { name: next, picks },
+    )
+      .then((data) => {
+        setSessionName(data.name);
+        setRenameModalOpen(false);
+        pushToast("Session renamed.", "success");
+      })
+      .catch((err: unknown) => {
+        console.error(err);
+        setRenameError(err instanceof Error ? err.message : "Rename failed");
+      })
+      .finally(() => setRenameSaving(false));
+  };
+
+  // 로드된 세션에서 픽이 바뀌면 500ms 디바운스 후 백그라운드 PUT.
+  // 목적: MyTeam 페이지가 DB 를 조회할 때 최신 픽이 반영되도록 (실시간 동기화).
+  // 첫 마운트 / 세션 전환 직후 bootstrap 이 picks 를 세팅하는 시점은 skip.
+  const autoSaveTimerRef = useRef<number | null>(null);
+  const skipFirstAutoSaveRef = useRef(true);
+
+  useEffect(() => {
+    skipFirstAutoSaveRef.current = true;
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!isLoadedMode || sessionId === null || !config || !sessionName) return;
+    if (skipFirstAutoSaveRef.current) {
+      skipFirstAutoSaveRef.current = false;
+      return;
+    }
+    if (autoSaveTimerRef.current !== null) {
+      window.clearTimeout(autoSaveTimerRef.current);
+    }
+    autoSaveTimerRef.current = window.setTimeout(() => {
+      apiPutAuth<SessionDetail, { name: string; picks: DraftPick[] }>(
+        `/api/draft/sessions/${sessionId}`,
+        { name: sessionName, picks },
+      ).catch((err: unknown) => {
+        console.error("Auto-save failed:", err);
+      });
+      autoSaveTimerRef.current = null;
+    }, 500);
+    return () => {
+      if (autoSaveTimerRef.current !== null) {
+        window.clearTimeout(autoSaveTimerRef.current);
+        autoSaveTimerRef.current = null;
+      }
+    };
+  }, [picks, isLoadedMode, sessionId, sessionName, config]);
+
   const closeSaveModal = () => {
     setSaveModalOpen(false);
     setSaveError(null);
@@ -1297,9 +1409,10 @@ export default function DraftPage() {
         onRedo={redoPicks}
         onDiscard={handleDiscardDraft}
         onNew={handleNewDraft}
-        onSave={openSaveModal}
+        onSave={handleSaveClick}
         onImport={openImportModal}
         onStartDraft={openStartDraft}
+        onRename={openRenameModal}
       />
 
       <FadeIn delayMs={60}>
@@ -1461,6 +1574,20 @@ export default function DraftPage() {
           saving={saving}
           onCancel={closeSaveModal}
           onConfirm={handleSaveConfirm}
+        />
+      )}
+
+      {renameModalOpen && (
+        <RenameSessionModal
+          nameInput={renameInput}
+          onChangeName={(next) => {
+            setRenameInput(next);
+            if (renameError) setRenameError(null);
+          }}
+          error={renameError}
+          saving={renameSaving}
+          onCancel={closeRenameModal}
+          onConfirm={handleRenameConfirm}
         />
       )}
 

--- a/fe/src/pages/MyTeamPage.tsx
+++ b/fe/src/pages/MyTeamPage.tsx
@@ -3,7 +3,7 @@
 // - 진입 시 GET /api/draft/sessions 로 사용자 세션 목록을 조회 →
 //   URL ?sessionId 가 있고 소유 세션이면 그 값, 없으면 가장 최근 세션을 default 로 사용
 // - 필터/정렬/검색은 전부 프론트에서 처리 (백엔드는 원시 데이터만 제공)
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import FadeIn from "../components/ui/FadeIn";
 import Skeleton from "../components/ui/Skeleton";
@@ -159,39 +159,60 @@ export default function MyTeamPage() {
   }, []);
 
   // ── 2단계: sessionId 가 결정되면 해당 세션의 My Team 데이터 로드 ──
+  // 재호출 가능하도록 콜백으로 분리 — visibilitychange 시 같은 로직으로 refetch.
+  const fetchTeam = useCallback(
+    (signal?: AbortSignal) => {
+      if (sessionId === null) return;
+      setLoading(true);
+      setError(null);
+      apiGetAuth<MyTeamPlayersResponse>(
+        "/api/my-team/players",
+        { sessionId },
+        signal,
+      )
+        .then((data) => {
+          if (signal?.aborted) return;
+          setPlayers(data.items);
+          setBudget({
+            total: data.totalBudget,
+            spent: data.spentBudget,
+            remaining: data.remainingBudget,
+          });
+        })
+        .catch((err: unknown) => {
+          if (err instanceof DOMException && err.name === "AbortError") return;
+          console.error(err);
+          setPlayers([]);
+          setError(err instanceof Error ? err.message : "Failed to load my team");
+        })
+        .finally(() => {
+          if (!signal?.aborted) setLoading(false);
+        });
+    },
+    [sessionId],
+  );
+
   useEffect(() => {
     if (sessionId === null) return;
-
     const controller = new AbortController();
-    setLoading(true);
-    setError(null);
-
-    apiGetAuth<MyTeamPlayersResponse>(
-      "/api/my-team/players",
-      { sessionId },
-      controller.signal
-    )
-      .then((data) => {
-        if (controller.signal.aborted) return;
-        setPlayers(data.items);
-        setBudget({
-          total: data.totalBudget,
-          spent: data.spentBudget,
-          remaining: data.remainingBudget,
-        });
-      })
-      .catch((err: unknown) => {
-        if (err instanceof DOMException && err.name === "AbortError") return;
-        console.error(err);
-        setPlayers([]);
-        setError(err instanceof Error ? err.message : "Failed to load my team");
-      })
-      .finally(() => {
-        if (!controller.signal.aborted) setLoading(false);
-      });
-
+    fetchTeam(controller.signal);
     return () => controller.abort();
-  }, [sessionId]);
+  }, [sessionId, fetchTeam]);
+
+  // 탭 전환 / 페이지 재가시화 시 최신 픽 데이터로 refetch.
+  // DraftPage 의 auto-save 가 푸시한 결과를 즉시 반영 — 두 페이지를 오갈 때 stale 방지.
+  useEffect(() => {
+    if (sessionId === null) return;
+    const onVisible = () => {
+      if (document.visibilityState === "visible") fetchTeam();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    window.addEventListener("focus", onVisible);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      window.removeEventListener("focus", onVisible);
+    };
+  }, [sessionId, fetchTeam]);
 
   // 현재 보고 있는 세션의 메타 정보 (제목 옆에 이름 표시용)
   const activeSession = useMemo(


### PR DESCRIPTION


## What
<!-- What did you do? -->
1. Save button on a loaded session no longer reopens the name modal. It PUTs directly with the existing name and shows a "Session saved." toast.
2. A new pencil icon next to the draft title opens a Rename modal so users can change a saved session name at any time.
3. DraftPage auto-saves loaded-mode picks to the backend with a 500ms debounce, so the DB stays current without an explicit Save click.
4. MyTeam page refetches on tab focus / visibilitychange. Combined with #3, picks made in the Draft page appear in MyTeam as soon as the user switches over.

## Why
<!-- Why did you do it? -->
1. Re-entering the same name every time was a pointless friction; the existing name is the obvious default for an already-named session.
2. Users had no way to rename a session after creating it — they had to delete and re-save. The pencil icon makes rename a one-click action.
3. MyTeam was reading stale DB data because picks only persisted on explicit Save. Auto-save makes the backend the live source of truth for loaded mode.
4. Even with auto-save, MyTeam previously only fetched on mount, so picks made while it was hidden never appeared. Refetching on focus closes the gap.

## Related Issue
<!-- e.g. #123 -->
#144 