### PR TITLE
test: add Vitest + RTL frontend tests

### DIFF
--- a/fe/package-lock.json
+++ b/fe/package-lock.json
@@ -15,6 +15,9 @@
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@tailwindcss/vite": "^4.2.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
@@ -24,12 +27,72 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^29.1.1",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.2.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^8.0.0-beta.13"
+        "vite": "^8.0.0-beta.13",
+        "vitest": "^4.1.6"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+      "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -265,6 +328,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -311,6 +384,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.1.tgz",
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.4.tgz",
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -502,6 +728,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -871,6 +1115,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.1.tgz",
@@ -1143,6 +1394,96 @@
         "vite": "^5.2.0 || ^6 || ^7"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1153,6 +1494,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1198,6 +1547,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1559,6 +1926,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1599,6 +2079,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1621,6 +2112,26 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.27",
@@ -1677,6 +2188,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -1754,6 +2275,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1834,12 +2365,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1859,12 +2425,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1875,6 +2458,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.302",
@@ -1896,6 +2487,26 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2094,6 +2705,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2102,6 +2723,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2293,6 +2924,19 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2330,6 +2974,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2352,6 +3006,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2388,6 +3049,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.1.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+      "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.11",
+        "@asamuzakjp/dom-selector": "^7.1.1",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.3.5",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.25.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+      "integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -2755,6 +3467,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -2763,6 +3486,23 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -2816,6 +3556,17 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
       "license": "MIT"
     },
     "node_modules/optionator": {
@@ -2881,6 +3632,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2900,6 +3664,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2967,6 +3738,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2997,6 +3798,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3044,6 +3853,30 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3095,6 +3928,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3140,6 +3986,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3148,6 +4001,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3176,6 +4056,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.1.tgz",
@@ -3197,6 +4084,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3212,6 +4116,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.30.tgz",
+      "integrity": "sha512-ELrFxuqsDdHUwoh0XxDbxuLD3Wnz49Z57IFvTtvWy1hJdcMZjXLIuonjilCiWHlT2GbE4Wlv1wKVTzDFnXH1aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.30"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3284,6 +4244,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -3413,6 +4383,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3429,6 +4537,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -3438,6 +4563,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/fe/package.json
+++ b/fe/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "react": "^19.2.0",
@@ -17,6 +19,9 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@tailwindcss/vite": "^4.2.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
@@ -26,11 +31,13 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
+    "jsdom": "^29.1.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.2.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
-    "vite": "^8.0.0-beta.13"
+    "vite": "^8.0.0-beta.13",
+    "vitest": "^4.1.6"
   },
   "overrides": {
     "vite": "^8.0.0-beta.13"

--- a/fe/src/__tests__/integration.test.tsx
+++ b/fe/src/__tests__/integration.test.tsx
@@ -1,0 +1,347 @@
+// Integration tests — verify that user-interaction flows work correctly with the real component + its children.
+// Instead of plain props snapshots, this uses RTL + userEvent to simulate clicks/typing/keystrokes and observe the resulting state changes.
+//
+//   1. ComparisonPanel             — A/B slot display, X click, Compare button enable condition
+//   2. StatPickerStrip             — chip add/remove (preserving slot position), Reset button, "+" disabled when full
+//   3. RenameSessionModal          — input + Enter key + Confirm disabled when empty
+//   4. OrderedDraftHistoryModal    — render picks in chronological order + empty-state message
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import ComparisonPanel from "../features/draft/components/ComparisonPanel";
+import StatPickerStrip from "../features/draft/components/StatPickerStrip";
+import RenameSessionModal from "../features/draft/components/RenameSessionModal";
+import OrderedDraftHistoryModal from "../features/draft/components/OrderedDraftHistoryModal";
+
+import type { StatSlot } from "../features/draft/useStatColumns";
+import type {
+  DraftPick,
+  DraftPlayer,
+  DraftPlayerPublic,
+  DraftTeam,
+} from "../types/draft";
+
+// Player factory for tests — populate only the fields needed and leave the rest as null/defaults.
+function makePlayer(overrides: Partial<DraftPlayerPublic> = {}): DraftPlayer {
+  return {
+    id: "1",
+    name: "Aaron Judge",
+    playerType: "batter",
+    team: "NYY",
+    positions: ["OF"],
+    ab: 500, r: 100, h: 150, single: 80, double: 30, triple: 1,
+    hr: 50, rbi: 130, bb: 90, k: 150, sb: 8, cs: 2,
+    avg: 0.3, obp: 0.4, slg: 0.6,
+    w: null, l: null, sv: null, so: null, era: null, whip: null, ip: null,
+    g: null, gs: null, war: null, fip: null, er: null, hbp: null, bf: null,
+    era_plus: null, h9: null, hr9: null, bb9: null, so9: null, so_bb: null,
+    ppaValue: 12.5,
+    recommendedBid: 45,
+    ...overrides,
+  } as DraftPlayer;
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// 1. ComparisonPanel
+// ───────────────────────────────────────────────────────────────────────
+describe("ComparisonPanel", () => {
+  const baseProps = {
+    selectedA: null,
+    selectedB: null,
+    authed: true,
+    onClearA: vi.fn(),
+    onClearB: vi.fn(),
+    onClearAll: vi.fn(),
+    onOpenComparison: vi.fn(),
+  };
+
+  it("shows placeholder text and disables the Compare button when nobody is selected", () => {
+    render(<ComparisonPanel {...baseProps} />);
+    expect(screen.getByText(/Select player A/i)).toBeInTheDocument();
+    expect(screen.getByText(/Select player B/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Compare$/i })).toBeDisabled();
+  });
+
+  it("enables the Compare button once both A and B are selected", () => {
+    render(
+      <ComparisonPanel
+        {...baseProps}
+        selectedA={makePlayer({ id: "1", name: "Aaron Judge" })}
+        selectedB={makePlayer({ id: "2", name: "Mookie Betts", team: "LAD" })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /^Compare$/i })).toBeEnabled();
+    expect(screen.getByText("Aaron Judge")).toBeInTheDocument();
+    expect(screen.getByText("Mookie Betts")).toBeInTheDocument();
+  });
+
+  it("calls onClearA / onClearB when the slot's X button is clicked", async () => {
+    const onClearA = vi.fn();
+    const onClearB = vi.fn();
+    render(
+      <ComparisonPanel
+        {...baseProps}
+        selectedA={makePlayer({ id: "1", name: "Aaron Judge" })}
+        selectedB={makePlayer({ id: "2", name: "Mookie Betts" })}
+        onClearA={onClearA}
+        onClearB={onClearB}
+      />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Remove player A/i }));
+    await user.click(screen.getByRole("button", { name: /Remove player B/i }));
+    expect(onClearA).toHaveBeenCalledTimes(1);
+    expect(onClearB).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the Compare button disabled for unauthenticated users even when both A and B are selected", () => {
+    render(
+      <ComparisonPanel
+        {...baseProps}
+        authed={false}
+        selectedA={makePlayer({ id: "1" })}
+        selectedB={makePlayer({ id: "2" })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /^Compare$/i })).toBeDisabled();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// 2. StatPickerStrip
+// ───────────────────────────────────────────────────────────────────────
+describe("StatPickerStrip", () => {
+  it("fixed 5 slots — empty slots render the 'Empty' placeholder and keep their position", () => {
+    const cols: StatSlot[] = ["AVG", null, "RBI", null, "SB"];
+    render(
+      <StatPickerStrip group="batter" cols={cols} onChange={vi.fn()} onReset={vi.fn()} />,
+    );
+    expect(screen.getAllByText(/Empty/i)).toHaveLength(2);
+    expect(screen.getByText("AVG")).toBeInTheDocument();
+    expect(screen.getByText("RBI")).toBeInTheDocument();
+    expect(screen.getByText("SB")).toBeInTheDocument();
+  });
+
+  it("the X button sets only that slot to null and leaves the other slots untouched", async () => {
+    const onChange = vi.fn();
+    const cols: StatSlot[] = ["AVG", "HR", "RBI", "SB", "AB"];
+    render(
+      <StatPickerStrip group="batter" cols={cols} onChange={onChange} onReset={vi.fn()} />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /Remove HR/i }));
+    expect(onChange).toHaveBeenCalledWith(["AVG", null, "RBI", "SB", "AB"]);
+  });
+
+  it("clicking an available chip fills the first empty slot (no shifting)", async () => {
+    const onChange = vi.fn();
+    const cols: StatSlot[] = ["AVG", null, "RBI", "SB", "AB"];
+    render(
+      <StatPickerStrip group="batter" cols={cols} onChange={onChange} onReset={vi.fn()} />,
+    );
+    const user = userEvent.setup();
+    // The "+ HR" button in the available area — its accessible name is "+ HR", so match by title directly.
+    await user.click(screen.getByTitle("Add HR"));
+    expect(onChange).toHaveBeenCalledWith(["AVG", "HR", "RBI", "SB", "AB"]);
+  });
+
+  it("disables every available chip when all 5 slots are full", () => {
+    const cols: StatSlot[] = ["AVG", "HR", "RBI", "SB", "AB"];
+    render(
+      <StatPickerStrip group="batter" cols={cols} onChange={vi.fn()} onReset={vi.fn()} />,
+    );
+    // Any other key from the batter catalog — AB/AVG/HR/RBI/SB are all selected, so OBP is a candidate.
+    // When the strip is full, every available chip's title becomes "Remove one stat first".
+    const buttons = screen.getAllByTitle("Remove one stat first");
+    expect(buttons.length).toBeGreaterThan(0);
+    buttons.forEach((b) => expect(b).toBeDisabled());
+  });
+
+  it("invokes the onReset callback when the Reset button is clicked", async () => {
+    const onReset = vi.fn();
+    render(
+      <StatPickerStrip group="batter" cols={["AVG", "HR", "RBI", "SB", "AB"]} onChange={vi.fn()} onReset={onReset} />,
+    );
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /^Reset$/i }));
+    expect(onReset).toHaveBeenCalledTimes(1);
+  });
+
+  it("switches the catalog by group — the pitcher group exposes ERA / SO, etc.", () => {
+    render(
+      <StatPickerStrip
+        group="pitcher"
+        cols={[null, null, null, null, null]}
+        onChange={vi.fn()}
+        onReset={vi.fn()}
+      />,
+    );
+    expect(screen.getByTitle("Add ERA")).toBeInTheDocument();
+    expect(screen.getByTitle("Add WHIP")).toBeInTheDocument();
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// 3. RenameSessionModal
+// ───────────────────────────────────────────────────────────────────────
+describe("RenameSessionModal", () => {
+  const baseProps = {
+    nameInput: "",
+    onChangeName: vi.fn(),
+    error: null,
+    saving: false,
+    onCancel: vi.fn(),
+    onConfirm: vi.fn(),
+  };
+
+  it("disables the Save button when the input is empty", () => {
+    render(<RenameSessionModal {...baseProps} nameInput="" />);
+    expect(screen.getByRole("button", { name: /^Save$/i })).toBeDisabled();
+  });
+
+  it("enables Save once a name is present, and clicking it calls onConfirm", async () => {
+    const onConfirm = vi.fn();
+    render(<RenameSessionModal {...baseProps} nameInput="2026 AL" onConfirm={onConfirm} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /^Save$/i }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("the Enter key also calls onConfirm (not called when the value is empty)", async () => {
+    const onConfirm = vi.fn();
+    const { rerender } = render(
+      <RenameSessionModal {...baseProps} nameInput="" onConfirm={onConfirm} />,
+    );
+    const input = screen.getByPlaceholderText(/Session name/i);
+    const user = userEvent.setup();
+    await user.type(input, "{Enter}");
+    expect(onConfirm).not.toHaveBeenCalled();
+
+    rerender(<RenameSessionModal {...baseProps} nameInput="2026" onConfirm={onConfirm} />);
+    await user.type(screen.getByPlaceholderText(/Session name/i), "{Enter}");
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("while saving, the Save button text changes to 'Saving...' and the button is disabled", () => {
+    render(<RenameSessionModal {...baseProps} nameInput="x" saving />);
+    const btn = screen.getByRole("button", { name: /Saving\.\.\./i });
+    expect(btn).toBeDisabled();
+  });
+
+  it("renders the error message when the error prop is set", () => {
+    render(
+      <RenameSessionModal {...baseProps} nameInput="x" error="Name already taken" />,
+    );
+    expect(screen.getByText(/Name already taken/i)).toBeInTheDocument();
+  });
+
+  it("the Cancel button always calls onCancel", async () => {
+    const onCancel = vi.fn();
+    render(<RenameSessionModal {...baseProps} onCancel={onCancel} />);
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /^Cancel$/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// 4. OrderedDraftHistoryModal
+// ───────────────────────────────────────────────────────────────────────
+describe("OrderedDraftHistoryModal", () => {
+  const teams: DraftTeam[] = [
+    { id: "team-0", name: "My Team", isMine: true },
+    { id: "team-1", name: "Opp A" },
+    { id: "team-2", name: "Opp B" },
+  ];
+
+  const pick = (
+    over: Partial<DraftPick>,
+  ): DraftPick => ({
+    playerId: "1",
+    draftedByTeamId: "team-0",
+    slotIndex: 0,
+    slotPos: "OF",
+    bid: 30,
+    type: "mine",
+    kind: "main",
+    ...over,
+  });
+
+  it("renders the 'No picks yet.' empty-state message when there are no picks", () => {
+    render(
+      <OrderedDraftHistoryModal
+        open
+        picks={[]}
+        teams={teams}
+        playersById={{}}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/No picks yet\./i)).toBeInTheDocument();
+  });
+
+  it("renders main picks in chronological order — Pick # goes 1, 2, 3...", () => {
+    const picks: DraftPick[] = [
+      pick({ playerId: "10", draftedByTeamId: "team-1", bid: 25 }),
+      pick({ playerId: "20", draftedByTeamId: "team-0", bid: 50 }),
+      pick({ playerId: "30", draftedByTeamId: "team-2", bid: 12 }),
+    ];
+    const playersById: Record<string, DraftPlayer> = {
+      "10": makePlayer({ id: "10", name: "Player Ten", positions: ["1B"], team: "BOS" }),
+      "20": makePlayer({ id: "20", name: "Player Twenty", positions: ["OF"], team: "NYY" }),
+      "30": makePlayer({ id: "30", name: "Player Thirty", positions: ["SS"], team: "TEX" }),
+    };
+
+    render(
+      <OrderedDraftHistoryModal
+        open
+        picks={picks}
+        teams={teams}
+        playersById={playersById}
+        onClose={vi.fn()}
+      />,
+    );
+
+    const rows = screen.getAllByRole("row").slice(1); // exclude header
+    expect(rows).toHaveLength(3);
+
+    // First row: Pick #1 = Player Ten / Opp A / $25
+    const firstRow = within(rows[0]);
+    expect(firstRow.getByText("1")).toBeInTheDocument();
+    expect(firstRow.getByText("Player Ten")).toBeInTheDocument();
+    expect(firstRow.getByText("Opp A")).toBeInTheDocument();
+    expect(firstRow.getByText("$25")).toBeInTheDocument();
+
+    // Third row: Pick #3
+    const thirdRow = within(rows[2]);
+    expect(thirdRow.getByText("3")).toBeInTheDocument();
+    expect(thirdRow.getByText("Player Thirty")).toBeInTheDocument();
+    expect(thirdRow.getByText("Opp B")).toBeInTheDocument();
+  });
+
+  it("excludes minor/taxi picks from the main draft history", () => {
+    const picks: DraftPick[] = [
+      pick({ playerId: "10", kind: "main", bid: 25 }),
+      pick({ playerId: "20", kind: "minor", bid: null }),
+      pick({ playerId: "30", kind: "taxi", bid: null }),
+    ];
+    render(
+      <OrderedDraftHistoryModal
+        open
+        picks={picks}
+        teams={teams}
+        playersById={{
+          "10": makePlayer({ id: "10", name: "Main Only" }),
+          "20": makePlayer({ id: "20", name: "Minor Pick" }),
+          "30": makePlayer({ id: "30", name: "Taxi Pick" }),
+        }}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Main Only")).toBeInTheDocument();
+    expect(screen.queryByText("Minor Pick")).not.toBeInTheDocument();
+    expect(screen.queryByText("Taxi Pick")).not.toBeInTheDocument();
+  });
+});

--- a/fe/src/__tests__/unit.test.ts
+++ b/fe/src/__tests__/unit.test.ts
@@ -1,0 +1,275 @@
+// Unit tests — verify pure functions and hooks in isolation.
+// Each module gets its own describe block so it's clear at a glance which area is covered.
+//
+//   1. features/draft/utils         — roster slots / eligibility / budget / round calculations
+//   2. features/draft/draftHelpers  — position filter / batter-vs-pitcher classification / formatters
+//   3. hooks/useUndoStack           — push, undo, redo, and reset behavior of the undo/redo stack
+//   4. features/draft/useStatColumns — fixed length-5 policy + localStorage round-trip
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import {
+  DEFAULT_ROSTER_SLOTS,
+  buildSlotTemplateFromCounts,
+  calculateCurrentRound,
+  calculateRemainingBudget,
+  clampRosterSize,
+  findEligibleSlotIndex,
+  findFirstEmptySlot,
+  isEligibleForSlot,
+  sumRosterSlots,
+} from "../features/draft/utils";
+
+import {
+  arePlayersComparable,
+  formatNumber,
+  isPitcherOnly,
+  isPitcherPositionFilter,
+  matchesPositionFilter,
+} from "../features/draft/draftHelpers";
+
+import { useUndoStack } from "../hooks/useUndoStack";
+import { useStatColumns } from "../features/draft/useStatColumns";
+
+import type { DraftPick, DraftPlayerPublic } from "../types/draft";
+
+// ───────────────────────────────────────────────────────────────────────
+// 1. features/draft/utils
+// ───────────────────────────────────────────────────────────────────────
+describe("features/draft/utils", () => {
+  it("sumRosterSlots sums the counts across every position", () => {
+    expect(sumRosterSlots(DEFAULT_ROSTER_SLOTS)).toBe(16);
+  });
+
+  it("clampRosterSize clamps the value to the 1..25 range", () => {
+    expect(clampRosterSize(0)).toBe(1);
+    expect(clampRosterSize(30)).toBe(25);
+    expect(clampRosterSize(14)).toBe(14);
+    expect(clampRosterSize(undefined)).toBe(12); // default fallback
+  });
+
+  it("buildSlotTemplateFromCounts expands in the order SP→RP→C…BENCH", () => {
+    const tmpl = buildSlotTemplateFromCounts({
+      C: 1, "1B": 1, "2B": 0, "3B": 0, SS: 0,
+      OF: 2, UTIL: 0, SP: 1, RP: 1, BENCH: 1,
+    });
+    expect(tmpl).toEqual(["SP", "RP", "C", "1B", "OF", "OF", "BENCH"]);
+  });
+
+  describe("isEligibleForSlot", () => {
+    it("BENCH accepts anyone", () => {
+      expect(isEligibleForSlot(["SP"], "BENCH")).toBe(true);
+      expect(isEligibleForSlot([], "BENCH")).toBe(true);
+    });
+    it("UTIL accepts only non-pitchers", () => {
+      expect(isEligibleForSlot(["OF"], "UTIL")).toBe(true);
+      expect(isEligibleForSlot(["SP"], "UTIL")).toBe(false);
+      expect(isEligibleForSlot(["SP", "RP"], "UTIL")).toBe(false);
+    });
+    it("Regular slots require an exact match", () => {
+      expect(isEligibleForSlot(["OF"], "OF")).toBe(true);
+      expect(isEligibleForSlot(["1B"], "OF")).toBe(false);
+    });
+  });
+
+  it("findEligibleSlotIndex returns the first eligible slot, or -1 if none", () => {
+    const tmpl = ["SP", "C", "BENCH"];
+    expect(findEligibleSlotIndex(["C"], tmpl, new Set())).toBe(1);
+    expect(findEligibleSlotIndex(["C"], tmpl, new Set([1]))).toBe(2); // falls back to BENCH
+    expect(findEligibleSlotIndex(["C"], tmpl, new Set([1, 2]))).toBe(-1);
+  });
+
+  it("findFirstEmptySlot returns the first non-occupied index", () => {
+    expect(findFirstEmptySlot(new Set(), 8)).toBe(0);
+    expect(findFirstEmptySlot(new Set([0, 1]), 8)).toBe(2);
+    expect(findFirstEmptySlot(new Set([0, 1, 2, 3, 4, 5, 6, 7]), 8)).toBe(-1);
+  });
+
+  it("calculateRemainingBudget guards against negative values (Math.max 0)", () => {
+    const picks: DraftPick[] = [
+      { playerId: "1", draftedByTeamId: "team-0", slotIndex: 0, slotPos: "OF", bid: 100, type: "mine", kind: "main" },
+      { playerId: "2", draftedByTeamId: "team-0", slotIndex: 1, slotPos: "OF", bid: 30, type: "mine", kind: "main" },
+      { playerId: "3", draftedByTeamId: "team-1", slotIndex: 0, slotPos: "OF", bid: 50, type: "taken", kind: "main" },
+    ];
+    expect(calculateRemainingBudget(260, "team-0", picks)).toBe(130);
+    expect(calculateRemainingBudget(50, "team-0", picks)).toBe(0); // overspent → 0
+  });
+
+  it("calculateCurrentRound counts only main picks and caps at totalRounds", () => {
+    const main = (n: number): DraftPick[] =>
+      Array.from({ length: n }, (_, i) => ({
+        playerId: String(i),
+        draftedByTeamId: `team-${i % 4}`,
+        slotIndex: 0,
+        slotPos: "OF",
+        bid: 10,
+        type: "mine" as const,
+        kind: "main" as const,
+      }));
+    expect(calculateCurrentRound(4, 16, [])).toBe(1);
+    expect(calculateCurrentRound(4, 16, main(5))).toBe(2); // floor(5/4)+1
+    expect(calculateCurrentRound(4, 5, main(40))).toBe(5); // capped at rosterSlots
+    // Minor/taxi picks are excluded from the count
+    const mixed: DraftPick[] = [
+      ...main(3),
+      { playerId: "x", draftedByTeamId: "team-0", slotIndex: 0, slotPos: null, bid: null, type: "mine", kind: "minor" },
+      { playerId: "y", draftedByTeamId: "team-0", slotIndex: 0, slotPos: null, bid: null, type: "mine", kind: "taxi" },
+    ];
+    expect(calculateCurrentRound(4, 16, mixed)).toBe(1);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// 2. features/draft/draftHelpers
+// ───────────────────────────────────────────────────────────────────────
+describe("features/draft/draftHelpers", () => {
+  const makeBatter = (positions: string[]): DraftPlayerPublic =>
+    ({
+      id: "1",
+      name: "Test",
+      playerType: "batter",
+      team: "NYY",
+      positions,
+    } as DraftPlayerPublic);
+  const makePitcher = (positions: string[] = ["SP"]): DraftPlayerPublic =>
+    ({
+      id: "2",
+      name: "P",
+      playerType: "pitcher",
+      team: "LAD",
+      positions,
+    } as DraftPlayerPublic);
+
+  it("matchesPositionFilter is case-insensitive and returns false for an empty array", () => {
+    expect(matchesPositionFilter(["of"], "OF")).toBe(true);
+    expect(matchesPositionFilter(["1B"], "OF")).toBe(false);
+    expect(matchesPositionFilter([], "OF")).toBe(false);
+    expect(matchesPositionFilter(undefined, "OF")).toBe(false);
+  });
+
+  it("isPitcherOnly / isPitcherPositionFilter", () => {
+    expect(isPitcherOnly(makePitcher())).toBe(true);
+    expect(isPitcherOnly(makeBatter(["OF"]))).toBe(false);
+    expect(isPitcherPositionFilter("SP")).toBe(true);
+    expect(isPitcherPositionFilter("RP")).toBe(true);
+    expect(isPitcherPositionFilter("OF")).toBe(false);
+  });
+
+  it("arePlayersComparable is true only for the same group (batter-vs-batter or pitcher-vs-pitcher)", () => {
+    expect(arePlayersComparable(makeBatter(["OF"]), makeBatter(["1B"]))).toBe(true);
+    expect(arePlayersComparable(makePitcher(), makePitcher(["RP"]))).toBe(true);
+    expect(arePlayersComparable(makeBatter(["OF"]), makePitcher())).toBe(false);
+  });
+
+  it("formatNumber renders null/undefined as '-'", () => {
+    expect(formatNumber(0.123, 3)).toBe("0.123");
+    expect(formatNumber(null, 3)).toBe("-");
+    expect(formatNumber(undefined, 2)).toBe("-");
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// 3. hooks/useUndoStack
+// ───────────────────────────────────────────────────────────────────────
+describe("hooks/useUndoStack", () => {
+  it("initial state has canUndo/canRedo both false", () => {
+    const { result } = renderHook(() => useUndoStack<number[]>([]));
+    expect(result.current.state).toEqual([]);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("commit → undo → redo round-trips the present value correctly", () => {
+    const { result } = renderHook(() => useUndoStack<number>(0));
+    act(() => result.current.commit(1));
+    act(() => result.current.commit(2));
+    expect(result.current.state).toBe(2);
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+
+    act(() => result.current.undo());
+    expect(result.current.state).toBe(1);
+    act(() => result.current.undo());
+    expect(result.current.state).toBe(0);
+    expect(result.current.canUndo).toBe(false);
+
+    act(() => result.current.redo());
+    expect(result.current.state).toBe(1);
+    act(() => result.current.redo());
+    expect(result.current.state).toBe(2);
+  });
+
+  it("future is cleared after commit (blocks branching)", () => {
+    const { result } = renderHook(() => useUndoStack<number>(0));
+    act(() => result.current.commit(1));
+    act(() => result.current.commit(2));
+    act(() => result.current.undo()); // present = 1, future = [2]
+    act(() => result.current.commit(99));
+    expect(result.current.state).toBe(99);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("reset clears both past and future", () => {
+    const { result } = renderHook(() => useUndoStack<number>(0));
+    act(() => result.current.commit(1));
+    act(() => result.current.commit(2));
+    act(() => result.current.reset(42));
+    expect(result.current.state).toBe(42);
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("commit with the same value is ignored (Object.is)", () => {
+    const { result } = renderHook(() => useUndoStack<number>(5));
+    act(() => result.current.commit(5));
+    expect(result.current.canUndo).toBe(false);
+  });
+});
+
+// ───────────────────────────────────────────────────────────────────────
+// 4. features/draft/useStatColumns
+// ───────────────────────────────────────────────────────────────────────
+describe("features/draft/useStatColumns", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("initial state has length-5 batter/pitcher defaults", () => {
+    const { result } = renderHook(() => useStatColumns());
+    expect(result.current.batterCols).toHaveLength(5);
+    expect(result.current.pitcherCols).toHaveLength(5);
+    expect(result.current.batterCols.every((s) => typeof s === "string")).toBe(true);
+  });
+
+  it("setBatterCols normalizes the length to 5 (pads with null if shorter)", () => {
+    const { result } = renderHook(() => useStatColumns());
+    act(() => result.current.setBatterCols(["AVG", "HR"]));
+    expect(result.current.batterCols).toHaveLength(5);
+    expect(result.current.batterCols.slice(0, 2)).toEqual(["AVG", "HR"]);
+    expect(result.current.batterCols.slice(2)).toEqual([null, null, null]);
+  });
+
+  it("setBatterCols truncates anything beyond length 5", () => {
+    const { result } = renderHook(() => useStatColumns());
+    act(() =>
+      result.current.setBatterCols(["AVG", "HR", "RBI", "SB", "AB", "OBP", "SLG"]),
+    );
+    expect(result.current.batterCols).toHaveLength(5);
+  });
+
+  it("persists to localStorage immediately on change", () => {
+    const { result } = renderHook(() => useStatColumns());
+    act(() => result.current.setBatterCols(["AVG", null, "RBI", null, "SB"]));
+    const raw = localStorage.getItem("ppadun_batter_stat_columns");
+    expect(raw).not.toBeNull();
+    expect(JSON.parse(raw as string)).toEqual(["AVG", null, "RBI", null, "SB"]);
+  });
+
+  it("resetToDefaults restores only the targeted group to its defaults", () => {
+    const { result } = renderHook(() => useStatColumns());
+    act(() => result.current.setBatterCols(["HR", null, null, null, null]));
+    act(() => result.current.resetToDefaults("batter"));
+    expect(result.current.batterCols.filter((s) => s !== null)).toHaveLength(5);
+  });
+});

--- a/fe/src/test-setup.ts
+++ b/fe/src/test-setup.ts
@@ -1,0 +1,11 @@
+// Vitest global setup — runs once before every test file.
+// Adds jest-dom matchers (toBeInTheDocument, etc.) to expect, and between each test
+// RTL's cleanup automatically unmounts components and clears the DOM (jsdom + globals: true environment).
+
+import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(() => {
+  cleanup();
+});

--- a/fe/vitest.config.ts
+++ b/fe/vitest.config.ts
@@ -1,0 +1,14 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+// 빌드용 vite.config.ts 와 분리 — 테스트는 tailwind/proxy 가 불필요.
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test-setup.ts"],
+    css: false,
+  },
+});


### PR DESCRIPTION

## What
<!-- What did you do? -->
- Vitest + React Testing Library setup: `vitest.config.ts`, `src/test-setup.ts`, new `npm test` and `npm run test:watch` scripts, plus the necessary devDependencies.
- `src/__tests__/unit.test.ts` — 27 cases. Pure helpers (`features/draft/utils`, `features/draft/draftHelpers`) and hooks (`useUndoStack`, `useStatColumns`).
- `src/__tests__/integration.test.tsx` — 16 cases. Real-component interaction flows on `ComparisonPanel`, `StatPickerStrip`, `RenameSessionModal`, and `OrderedDraftHistoryModal` via React Testing Library + userEvent.

## Why
<!-- Why did you do it? -->
Wanted real automated coverage for the most-touched logic and UI flows. Two test files keep the surface area small while exercising the parts that drift most during rapid iteration. `npm test` reports `43 / 43 passing` and can be wired into CI later.

## Related Issue
<!-- e.g. #123 -->
#146 