### PR TITLE
dynamic sort, drag eligibility highlighting, drag-time page scroll

### DIFF
--- a/fe/src/features/draft/components/DraftRoomBoard.tsx
+++ b/fe/src/features/draft/components/DraftRoomBoard.tsx
@@ -254,6 +254,24 @@ export default function DraftRoomBoard({
                         ? "ring-2 ring-rose-400/60"
                         : "";
 
+                      // While a drag is in progress, paint every slot with its eligibility
+                      // (green = droppable, red = not) so the user can see all valid targets
+                      // at a glance instead of hovering one at a time. The source slot is dimmed.
+                      const dragMode = draggingFrom !== null;
+                      const isSource =
+                        dragMode &&
+                        draggingFrom?.teamId === team.id &&
+                        draggingFrom?.index === slotIndex;
+                      const dragEligible =
+                        dragMode && !isSource ? isHoverEligible(team.id, slotIndex) : null;
+                      const dragTintClass =
+                        dragEligible === true
+                          ? "border-emerald-400/55 bg-emerald-500/15"
+                          : dragEligible === false
+                            ? "border-rose-400/55 bg-rose-500/12"
+                            : "";
+                      const sourceDimClass = isSource ? "opacity-40" : "";
+
                       const dndProps = {
                         onDragOver: (e: React.DragEvent) => {
                           if (draggingFrom === null) return;
@@ -323,8 +341,10 @@ export default function DraftRoomBoard({
                             {...dndProps}
                             className={[
                               // Pick card colors follow the owning team's accent — my team (sky) / each opponent's unique color.
+                              // During a drag, the team accent is replaced by the green/red eligibility tint.
                               "relative rounded-xl border px-3 py-2 text-left transition",
-                              accent.slot,
+                              dragMode && !isSource ? dragTintClass : accent.slot,
+                              sourceDimClass,
                               "cursor-grab active:cursor-grabbing",
                               hoverRingClass,
                             ].join(" ")}
@@ -369,7 +389,11 @@ export default function DraftRoomBoard({
                           key={`${team.id}-${slotIndex}`}
                           {...dndProps}
                           className={[
-                            "rounded-xl border border-dashed border-white/10 bg-black/15 px-3 py-2 text-[11px] text-white/25 transition",
+                            "rounded-xl border border-dashed px-3 py-2 text-[11px] transition",
+                            // Empty slot: neutral by default; turns green/red during a drag.
+                            dragMode
+                              ? `${dragTintClass} text-white/40`
+                              : "border-white/10 bg-black/15 text-white/25",
                             hoverRingClass,
                           ].join(" ")}
                         >

--- a/fe/src/features/draft/components/DraftRoomBoard.tsx
+++ b/fe/src/features/draft/components/DraftRoomBoard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { DraftPick, DraftPickKind, DraftPlayer, DraftTeam } from "../../../types/draft";
 import { MINOR_TAXI_SLOT_COUNT, isEligibleForSlot, teamAccentClass } from "../utils";
 
@@ -68,6 +68,48 @@ export default function DraftRoomBoard({
     index: number;
     ok: boolean;
   } | null>(null);
+
+  // While a drag is in progress, HTML5 native drag suppresses page scrolling.
+  // We restore it by (1) auto-scrolling when the mouse hovers the top/bottom edge
+  // of the viewport, and (2) intercepting wheel events and forwarding them to window.scrollBy.
+  useEffect(() => {
+    if (draggingFrom === null) return;
+
+    const EDGE_PX = 80;       // distance from the viewport edge that triggers auto-scroll
+    const SCROLL_STEP = 14;   // px scrolled per animation frame while the mouse stays in the edge zone
+    let scrollDir = 0;        // -1 = up, 0 = idle, 1 = down
+    let rafId = 0;
+
+    const tick = () => {
+      if (scrollDir !== 0) {
+        window.scrollBy(0, scrollDir * SCROLL_STEP);
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+    rafId = requestAnimationFrame(tick);
+
+    const onDragOver = (e: DragEvent) => {
+      const y = e.clientY;
+      const h = window.innerHeight;
+      if (y < EDGE_PX) scrollDir = -1;
+      else if (y > h - EDGE_PX) scrollDir = 1;
+      else scrollDir = 0;
+    };
+
+    const onWheel = (e: WheelEvent) => {
+      // During HTML5 drag, the browser often blocks default wheel scrolling — drive it manually.
+      window.scrollBy(0, e.deltaY);
+    };
+
+    document.addEventListener("dragover", onDragOver);
+    document.addEventListener("wheel", onWheel, { passive: true });
+
+    return () => {
+      cancelAnimationFrame(rafId);
+      document.removeEventListener("dragover", onDragOver);
+      document.removeEventListener("wheel", onWheel);
+    };
+  }, [draggingFrom]);
 
   // Filter picks to the current board and group them by team.
   const picksByTeam = useMemo(() => {

--- a/fe/src/features/draft/draftHelpers.ts
+++ b/fe/src/features/draft/draftHelpers.ts
@@ -14,6 +14,7 @@ import type {
   SessionSummary,
 } from "../../types/draft";
 import { DEFAULT_ROSTER_SLOTS, formatAvg, sumRosterSlots } from "./utils";
+import { getStatDef } from "./statColumns";
 
 // ── Constants ─────────────────────────────────────────────────────────
 
@@ -33,21 +34,23 @@ export const DEFAULT_POSITION_FILTERS: DraftPositionFilter[] = [
   "C", "1B", "2B", "3B", "SS", "OF", "UTIL", "SP", "RP",
 ];
 
-export const BATTER_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
-  { value: "score_desc", label: "By Score" },
-  { value: "avg_desc",   label: "By AVG" },
-  { value: "hr_desc",    label: "By HR" },
-  { value: "rbi_desc",   label: "By RBI" },
-  { value: "sb_desc",    label: "By SB" },
-];
-
-export const PITCHER_SORT_OPTIONS: { value: DraftSort; label: string }[] = [
-  { value: "score_desc", label: "By Score" },
-  { value: "avg_desc",   label: "By ERA" },
-  { value: "hr_desc",    label: "By SO" },
-  { value: "rbi_desc",   label: "By W" },
-  { value: "sb_desc",    label: "By SV" },
-];
+// Build the Sort dropdown options dynamically — "By Score" always first, then one
+// option per currently-selected stat slot (null slots skipped). Pure function so
+// it can be memoized in the page component.
+export function buildSortOptions(
+  statKeys: readonly (string | null)[],
+): { value: DraftSort; label: string }[] {
+  const opts: { value: DraftSort; label: string }[] = [
+    { value: "score_desc", label: "By Score" },
+  ];
+  for (const key of statKeys) {
+    if (key === null) continue;
+    const def = getStatDef(key);
+    if (!def) continue;
+    opts.push({ value: `stat:${key}` as DraftSort, label: `By ${def.label}` });
+  }
+  return opts;
+}
 
 // ── Inline API response & sessionStorage payload types ────────────────
 

--- a/fe/src/features/draft/statColumns.ts
+++ b/fe/src/features/draft/statColumns.ts
@@ -21,6 +21,9 @@ export type StatDef = {
   group: StatGroup;
   accessor: (p: DraftPlayerPublic) => number | null | undefined;
   format: (v: number | null | undefined) => string;
+  // For pitcher rate stats (ERA / WHIP / FIP / runs allowed, etc.), lower values are better.
+  // When sorting "best first", these need the comparator direction flipped.
+  lowerIsBetter?: boolean;
 };
 
 const formatInt = (v: number | null | undefined): string =>
@@ -53,29 +56,29 @@ export const STAT_DEFS: readonly StatDef[] = [
 
   // ── Pitcher (24) ───────────────────────────────────────────────────
   { key: "W",        label: "W",     group: "pitcher", accessor: (p) => p.w,        format: formatInt },
-  { key: "L",        label: "L",     group: "pitcher", accessor: (p) => p.l,        format: formatInt },
+  { key: "L",        label: "L",     group: "pitcher", accessor: (p) => p.l,        format: formatInt, lowerIsBetter: true },
   { key: "SV",       label: "SV",    group: "pitcher", accessor: (p) => p.sv,       format: formatInt },
   { key: "SO",       label: "SO",    group: "pitcher", accessor: (p) => p.so,       format: formatInt },
-  { key: "ERA",      label: "ERA",   group: "pitcher", accessor: (p) => p.era,      format: formatDecimal(2) },
-  { key: "WHIP",     label: "WHIP",  group: "pitcher", accessor: (p) => p.whip,     format: formatDecimal(2) },
+  { key: "ERA",      label: "ERA",   group: "pitcher", accessor: (p) => p.era,      format: formatDecimal(2), lowerIsBetter: true },
+  { key: "WHIP",     label: "WHIP",  group: "pitcher", accessor: (p) => p.whip,     format: formatDecimal(2), lowerIsBetter: true },
   { key: "IP",       label: "IP",    group: "pitcher", accessor: (p) => p.ip,       format: formatDecimal(1) },
   { key: "G",        label: "G",     group: "pitcher", accessor: (p) => p.g,        format: formatInt },
   { key: "GS",       label: "GS",    group: "pitcher", accessor: (p) => p.gs,       format: formatInt },
   { key: "WAR",      label: "WAR",   group: "pitcher", accessor: (p) => p.war,      format: formatDecimal(1) },
-  { key: "FIP",      label: "FIP",   group: "pitcher", accessor: (p) => p.fip,      format: formatDecimal(2) },
+  { key: "FIP",      label: "FIP",   group: "pitcher", accessor: (p) => p.fip,      format: formatDecimal(2), lowerIsBetter: true },
   // 4 overlapping field names — internal key prefixed to stay unique,
   // user-facing label stays as the simple stat abbreviation.
-  { key: "P_H",      label: "H",     group: "pitcher", accessor: (p) => p.h,        format: formatInt },
-  { key: "P_R",      label: "R",     group: "pitcher", accessor: (p) => p.r,        format: formatInt },
-  { key: "ER",       label: "ER",    group: "pitcher", accessor: (p) => p.er,       format: formatInt },
-  { key: "P_HR",     label: "HR",    group: "pitcher", accessor: (p) => p.hr,       format: formatInt },
-  { key: "P_BB",     label: "BB",    group: "pitcher", accessor: (p) => p.bb,       format: formatInt },
-  { key: "HBP",      label: "HBP",   group: "pitcher", accessor: (p) => p.hbp,      format: formatInt },
+  { key: "P_H",      label: "H",     group: "pitcher", accessor: (p) => p.h,        format: formatInt, lowerIsBetter: true },
+  { key: "P_R",      label: "R",     group: "pitcher", accessor: (p) => p.r,        format: formatInt, lowerIsBetter: true },
+  { key: "ER",       label: "ER",    group: "pitcher", accessor: (p) => p.er,       format: formatInt, lowerIsBetter: true },
+  { key: "P_HR",     label: "HR",    group: "pitcher", accessor: (p) => p.hr,       format: formatInt, lowerIsBetter: true },
+  { key: "P_BB",     label: "BB",    group: "pitcher", accessor: (p) => p.bb,       format: formatInt, lowerIsBetter: true },
+  { key: "HBP",      label: "HBP",   group: "pitcher", accessor: (p) => p.hbp,      format: formatInt, lowerIsBetter: true },
   { key: "BF",       label: "BF",    group: "pitcher", accessor: (p) => p.bf,       format: formatInt },
   { key: "ERA_PLUS", label: "ERA+",  group: "pitcher", accessor: (p) => p.era_plus, format: formatInt },
-  { key: "H9",       label: "H/9",   group: "pitcher", accessor: (p) => p.h9,       format: formatDecimal(2) },
-  { key: "HR9",      label: "HR/9",  group: "pitcher", accessor: (p) => p.hr9,      format: formatDecimal(2) },
-  { key: "BB9",      label: "BB/9",  group: "pitcher", accessor: (p) => p.bb9,      format: formatDecimal(2) },
+  { key: "H9",       label: "H/9",   group: "pitcher", accessor: (p) => p.h9,       format: formatDecimal(2), lowerIsBetter: true },
+  { key: "HR9",      label: "HR/9",  group: "pitcher", accessor: (p) => p.hr9,      format: formatDecimal(2), lowerIsBetter: true },
+  { key: "BB9",      label: "BB/9",  group: "pitcher", accessor: (p) => p.bb9,      format: formatDecimal(2), lowerIsBetter: true },
   { key: "SO9",      label: "SO/9",  group: "pitcher", accessor: (p) => p.so9,      format: formatDecimal(2) },
   { key: "SO_BB",    label: "SO/BB", group: "pitcher", accessor: (p) => p.so_bb,    format: formatDecimal(2) },
 ];

--- a/fe/src/pages/DraftPage.tsx
+++ b/fe/src/pages/DraftPage.tsx
@@ -48,10 +48,9 @@ import {
   isEligibleForSlot,
 } from "../features/draft/utils";
 import {
-  BATTER_SORT_OPTIONS,
+  buildSortOptions,
   DEFAULT_DRAFT_CONFIG,
   DEFAULT_POSITION_FILTERS,
-  PITCHER_SORT_OPTIONS,
   UNSAVED_DRAFT_KEY,
   arePlayersComparable,
   buildTeamsFromConfig,
@@ -59,12 +58,8 @@ import {
   isPitcherPositionFilter,
   matchesPositionFilter,
   mergePlayersWithValues,
-  powerSortValue,
-  primaryRateSortValue,
-  productionSortValue,
   removeUnsavedDraftStorage,
   setActiveDraftSessionId,
-  speedSortValue,
   type DraftPlayersResponse,
   type DraftPlayerValuesResponse,
   type SessionsListResponse,
@@ -207,16 +202,26 @@ export default function DraftPage() {
   const [sort, setSort] = useState<DraftSort>("score_desc");
   const [page, setPage] = useState(1);
 
-  // Filter/sort options are no longer returned by the server — use the constants directly
+  // Filter/sort options are no longer returned by the server — derived locally.
   const positionFilters = DEFAULT_POSITION_FILTERS;
   const showingPitcherColumns = isPitcherPositionFilter(position);
-  const sortOptions = showingPitcherColumns ? PITCHER_SORT_OPTIONS : BATTER_SORT_OPTIONS;
 
   // The user-selected 5 stat columns (separately for batters/pitchers) — persisted in localStorage.
   const { batterCols, pitcherCols, setBatterCols, setPitcherCols, resetToDefaults: resetStatColumns } = useStatColumns();
   const activeStatKeys = showingPitcherColumns ? pitcherCols : batterCols;
   // If a slot is null, the header label is an empty string too — so neighboring columns don't shift.
   const statColumnLabels = activeStatKeys.map((k) => (k ? getStatDef(k)?.label ?? k : ""));
+
+  // Sort dropdown options track the currently selected stat columns — "By Score" + one entry per filled slot.
+  const sortOptions = useMemo(() => buildSortOptions(activeStatKeys), [activeStatKeys]);
+
+  // If the current sort key drops out of the available options (e.g. user removed that
+  // stat from the strip, or switched between batter/pitcher groups), fall back to "score_desc".
+  useEffect(() => {
+    if (!sortOptions.some((opt) => opt.value === sort)) {
+      setSort("score_desc");
+    }
+  }, [sortOptions, sort]);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -317,19 +322,19 @@ export default function DraftPage() {
     result = result.filter((p) => matchesPositionFilter(p.positions, position));
 
     const sorted = [...result].sort((a, b) => {
-      switch (sort) {
-        case "avg_desc":
-          return primaryRateSortValue(b) - primaryRateSortValue(a);
-        case "hr_desc":
-          return powerSortValue(b) - powerSortValue(a);
-        case "rbi_desc":
-          return productionSortValue(b) - productionSortValue(a);
-        case "sb_desc":
-          return speedSortValue(b) - speedSortValue(a);
-        case "score_desc":
-        default:
-          return (b.ppaValue ?? 0) - (a.ppaValue ?? 0);
+      // Dynamic stat sort — `stat:KEY` uses the StatDef accessor for whichever
+      // column the user picked. lowerIsBetter (ERA / WHIP / etc.) flips direction.
+      if (typeof sort === "string" && sort.startsWith("stat:")) {
+        const key = sort.slice(5);
+        const def = getStatDef(key);
+        if (def) {
+          const av = def.accessor(a) ?? 0;
+          const bv = def.accessor(b) ?? 0;
+          return def.lowerIsBetter ? av - bv : bv - av;
+        }
       }
+      // Fallback / "score_desc" — PPA-DUN value, highest first.
+      return (b.ppaValue ?? 0) - (a.ppaValue ?? 0);
     });
 
     return sorted;

--- a/fe/src/types/draft.ts
+++ b/fe/src/types/draft.ts
@@ -202,13 +202,11 @@ export type PlayerNote = {
  * - _desc: descending (highest first).
  * - _asc: ascending.
  */
-export type DraftSort =
-  | "score_desc"
-  | "score_asc"
-  | "avg_desc"
-  | "hr_desc"
-  | "rbi_desc"
-  | "sb_desc";
+// Sort options for the player list.
+//   - "score_desc" / "score_asc" — sort by PPA-DUN value (the always-available default).
+//   - `stat:${key}` — sort by one of the currently selected stat columns (dynamic).
+//     The stat key matches a StatDef.key; lowerIsBetter (ERA / WHIP / …) is honored.
+export type DraftSort = "score_desc" | "score_asc" | `stat:${string}`;
 
 /**
  * DraftPositionFilter: position filter options.


### PR DESCRIPTION
## What
<!-- What did you do? -->
1. Sort dropdown options are now derived from the user's selected stat columns. "By Score" remains the default first entry; each filled stat slot adds one option in slot order. Removing a stat shrinks the dropdown, and the active sort falls back to "By Score" if it was the removed stat. StatDef gained a lowerIsBetter flag so ERA / WHIP / FIP-style stats sort in the correct direction.
2. Drag-time eligibility highlighting on the draft board: as soon as a player card starts a drag, every slot tints green (droppable) or red (not droppable). The source slot dims; the existing hover ring still marks the current target.
3. Page scrolling now works during a drag: hovering the cursor near the top or bottom edge of the viewport auto-scrolls the page, and the mouse wheel keeps working even though HTML5 native drag would normally block it.

## Why
<!-- Why did you do it? -->
- The fixed sort dropdown drifted out of sync as users customized their stat columns. Driving it from the picker keeps the page internally consistent.
- Without per-slot highlighting users had to hover one slot at a time to find out where they could drop a player. Showing every slot's status at drag start makes valid moves obvious.
- The player list pushes the draft board far below the fold. Without drag-time scrolling, a card couldn't reach slots that were off-screen. Edge auto-scroll + wheel passthrough close that gap.
 
## Related Issue
<!-- e.g. #123 -->
#152 